### PR TITLE
add doc for laravel builder dynamic where handler

### DIFF
--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -60,6 +60,31 @@ class ScormManager
             throw new InvalidScormArchiveException('invalid_scorm_data');
         }
 
+        /**
+         * ScormModel::whereOriginFile Query Builder style equals ScormModel::where('origin_file',$value)
+         * 
+         * From Laravel doc https://laravel.com/docs/5.0/queries#advanced-wheres.
+         * Dynamic Where Clauses
+         * You may even use "dynamic" where statements to fluently build where statements using magic methods:
+         * 
+         * Examples: 
+         * 
+         * $admin = DB::table('users')->whereId(1)->first();
+         * 
+         * $john = DB::table('users')
+         *         ->whereIdAndEmail(2, 'john@doe.com')
+         *         ->first();
+         * 
+         * $jane = DB::table('users')
+         *              ->whereNameOrAge('Jane', 22)
+         *              ->first();
+         * 
+         * 
+         * From laravel framework https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Query/Builder.php'
+         * 
+         *  Handle dynamic method calls into the method.
+         *  return $this->dynamicWhere($method, $parameters);
+         **/
         $scorm = ScormModel::whereOriginFile($scormData['identifier']);
         // Check if scom package already exists to drop old one.
         if (!$scorm->exists()) {


### PR DESCRIPTION
> ScormModel::whereOriginFile() 

- whereOriginFile Query Builder style equals where('origin_file',$value)

> From Laravel [doc](https://laravel.com/docs/5.0/queries#advanced-wheres) despite old version still supported.
Dynamic Where Clauses
You may even use "dynamic" where statements to fluently build where statements using magic methods:

```
$admin = DB::table('users')->whereId(1)->first();
 
$john = DB::table('users')
                    ->whereIdAndEmail(2, 'john@doe.com')
                    ->first();
 
$jane = DB::table('users')
                    ->whereNameOrAge('Jane', 22)
                    ->first();
```

**Update**
- From [laravel framework src](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Query/Builder.php)

```
/**
     * Handle dynamic method calls into the method.
     *
     * @param  string  $method
     * @param  array  $parameters
     * @return mixed
     *
     * @throws \BadMethodCallException
     */
    public function __call($method, $parameters)
    {
        if (static::hasMacro($method)) {
            return $this->macroCall($method, $parameters);
        }

        if (str_starts_with($method, 'where')) {
            return $this->dynamicWhere($method, $parameters);
        }

        static::throwBadMethodCallException($method);
    }
```
