### PR TITLE
Fix: Move the deleteScormFolder() method call to the deleteScorm() me…

### DIFF
--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -267,6 +267,8 @@ class ScormManager
         // Delete after the previous item is stored
         if ($model) {
             $this->deleteScormData($model);
+            // Delete folder from server
+            $this->deleteScormFolder($model->uuid);
             $model->delete(); // delete scorm
         }
     }
@@ -281,8 +283,6 @@ class ScormManager
             $oldSco->scoTrackings()->delete();
         }
         $model->scos()->delete(); // delete scos
-        // Delete folder from server
-        $this->deleteScormFolder($model->uuid);
     }
 
     /**


### PR DESCRIPTION
When calling the method
```
public function uploadScormArchive(UploadedFile $file, $uuid = null)
```
It calls within it the method:

```
private function saveScorm($file, $filename, $uuid = null)
```

Which calls the method:

```
private function generateScorm($file)
```

Which calls the `unzipper` method on the `scormDisk` object. The scorm path is cleared within the method body before the new content is made available.


As `deleteScormData` is called further down in the `uploadScormArchive` method, all content is removed after a successful upload.