### PR TITLE
Introduce UnzipperInterface to define a contract for SCORM zip extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,27 @@ $scorm = $scormManager->uploadScormFromUri($fileUrl);
 $scorm = $scormManager->uploadScormArchive($file, $existingUuid);
 ```
 
+### **⚙️ Choosing unzipper strategy**
+```php
+use Peopleaps\Scorm\Manager\ScormManager;
+use Peopleaps\Scorm\Contract\UnzipperInterface;
+use Peopleaps\Scorm\Manager\LambdaUnzipper;
+
+// 1. Laravel container (default — LocalUnzipper, no extra config needed)
+$manager = app(ScormManager::class);
+
+// 2. Swap to LambdaUnzipper via the container (e.g. in AppServiceProvider::register)
+$this->app->bind(UnzipperInterface::class, function () {
+    return new LambdaUnzipper(/* inject your client, bucket, etc. */);
+});
+
+// 3. Manual instantiation (e.g. in tests or outside Laravel)
+$manager = new ScormManager(
+    // ScormDisk is resolved for you when using the container;
+    // here you can wire a custom unzipper manually if needed.
+);
+```
+
 ### **📊 Metadata Structure**
 The system automatically captures:
 ```json

--- a/database/migrations/add_metadata_to_scorm_table.php.stub
+++ b/database/migrations/add_metadata_to_scorm_table.php.stub
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddMetadataToScormTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $tableNames = config('scorm.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/scorm.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+
+        Schema::table($tableNames['scorm_table'], function (Blueprint $table) {
+            $table->json('metadata')->nullable()->after('entry_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $tableNames = config('scorm.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/scorm.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+
+        Schema::table($tableNames['scorm_table'], function (Blueprint $table) {
+            $table->dropColumn('metadata');
+        });
+    }
+}

--- a/resources/lang/en-US/scorm.php
+++ b/resources/lang/en-US/scorm.php
@@ -9,6 +9,14 @@ return [
     'invalid_scorm_manifest_identifier' => 'Invalid SCORM manifest identifier.',
     'scorm_disk_not_define' => 'SCORM disk not define',
 
+    // ZIP file validation messages
+    'zip_file_not_found' => 'ZIP file does not exist.',
+    'zip_file_not_readable' => 'ZIP file is not readable.',
+    'imsmanifest_not_found' => 'imsmanifest.xml not found in ZIP archive.',
+    'file_not_found' => 'File does not exist.',
+    'not_a_zip_file' => 'File is not a ZIP archive.',
+    'zip_open_failed' => 'Failed to open ZIP file.',
+
     // SCORM Items/Children messages
     'default_organization_not_found_message' => 'SCORM item default organization not found.',
     'no_organization_found_message' => 'No organization found.',

--- a/src/Contract/UnzipperInterface.php
+++ b/src/Contract/UnzipperInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Peopleaps\Scorm\Contract;
+
+use Peopleaps\Scorm\Exception\StorageNotFoundException;
+
+/**
+ * Extracts a SCORM zip from the archive disk into the scorm (content) disk.
+ *
+ * Implementations may use local temp + ZipArchive (@see LocalUnzipper)
+ * or delegate to a remote service such as AWS Lambda.
+ */
+interface UnzipperInterface
+{
+    /**
+     * Extract the zip at $archiveKey on the archive disk into the scorm disk
+     * under the $targetUuid prefix.
+     *
+     * @throws StorageNotFoundException When the archive is missing or extraction fails.
+     */
+    public function extract(string $archiveKey, string $targetUuid): void;
+}

--- a/src/Library/ScormLib.php
+++ b/src/Library/ScormLib.php
@@ -109,10 +109,23 @@ class ScormLib
 
         foreach ($resources as $resource) {
             if (!is_null($resource->attributes)) {
-                $scormType = $resource->attributes->getNamedItemNS(
-                    $resource->lookupNamespaceUri('adlcp'),
-                    'scormType'
-                );
+                // Try to get the adlcp namespace URI
+                $adlcpNamespaceUri = $resource->lookupNamespaceUri('adlcp');
+                
+                // If adlcp namespace is not found, try common SCORM namespaces
+                if (empty($adlcpNamespaceUri)) {
+                    $adlcpNamespaceUri = 'http://www.adlnet.org/xsd/adlcp_v1p3';
+                }
+                
+                $scormType = null;
+                if (!empty($adlcpNamespaceUri)) {
+                    $scormType = $resource->attributes->getNamedItemNS($adlcpNamespaceUri, 'scormType');
+                }
+
+                // If still no scormType found, try without namespace (for SCORM 1.2)
+                if (is_null($scormType)) {
+                    $scormType = $resource->attributes->getNamedItem('scormType');
+                }
 
                 if (!is_null($scormType) && 'sco' === $scormType->nodeValue) {
                     $identifier = $resource->attributes->getNamedItem('identifier');

--- a/src/Library/ScormLib.php
+++ b/src/Library/ScormLib.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Peopleaps\Scorm\Library;
-
 
 use DOMDocument;
 use Peopleaps\Scorm\Entity\Sco;
@@ -11,6 +9,17 @@ use Illuminate\Support\Str;
 
 class ScormLib
 {
+    // SCORM namespace constants
+    const SCORM_12_NAMESPACE = null; // SCORM 1.2 doesn't use namespaces
+    const ADLCP_V1P2_NAMESPACE = 'http://www.adlnet.org/xsd/adlcp_rootv1p2';
+    const ADLCP_V1P3_NAMESPACE = 'http://www.adlnet.org/xsd/adlcp_v1p3';
+    const IMSSS_NAMESPACE = 'http://www.imsglobal.org/xsd/imsss';
+    const ADLSEQ_NAMESPACE = 'http://www.adlnet.org/xsd/adlseq_v1p3';
+    const ADLNAV_NAMESPACE = 'http://www.adlnet.org/xsd/adlnav_v1p3';
+
+    private $scormVersion = null;
+    private $namespaces = [];
+
     /**
      * Looks for the organization to use.
      *
@@ -21,10 +30,14 @@ class ScormLib
      */
     public function parseOrganizationsNode(DOMDocument $dom)
     {
+        // Detect SCORM version and namespaces first
+        $this->detectScormVersion($dom);
+        $this->extractNamespaces($dom);
+
         $organizationsList = $dom->getElementsByTagName('organizations');
         $resources = $dom->getElementsByTagName('resource');
 
-        \Log::info('parseOrganizationsNode: Found ' . $organizationsList->length . ' organizations and ' . $resources->length . ' resources');
+        \Log::info('parseOrganizationsNode: Found ' . $organizationsList->length . ' organizations, ' . $resources->length . ' resources, SCORM version: ' . $this->scormVersion);
 
         if ($organizationsList->length > 0) {
             $organizations = $organizationsList->item(0);
@@ -35,14 +48,12 @@ class ScormLib
                 && !is_null($organizations->attributes->getNamedItem('default'))
             ) {
                 $defaultOrganization = $organizations->attributes->getNamedItem('default')->nodeValue;
-                \Log::info('parseOrganizationsNode: Default organization found: ' . $defaultOrganization);
             } else {
                 $defaultOrganization = null;
-                \Log::info('parseOrganizationsNode: No default organization defined');
             }
+
             // No default organization is defined
             if (is_null($defaultOrganization)) {
-                \Log::info('parseOrganizationsNode: Looking for first organization...');
                 while (
                     !is_null($organization)
                     && 'organization' !== $organization->nodeName
@@ -51,16 +62,12 @@ class ScormLib
                 }
 
                 if (is_null($organization)) {
-                    \Log::info('parseOrganizationsNode: No organization found, falling back to parseResourceNodes');
-                    return $this->parseResourceNodes($resources);
-                } else {
-                    \Log::info('parseOrganizationsNode: Found organization, proceeding with parseItemNodes');
+                    \Log::info('parseOrganizationsNode: No organization found, using enhanced resource parsing');
+                    return $this->parseResourceNodesWithStructure($resources);
                 }
             }
             // A default organization is defined
-            // Look for it
             else {
-                \Log::info('parseOrganizationsNode: Looking for default organization: ' . $defaultOrganization);
                 while (
                     !is_null($organization)
                     && ('organization' !== $organization->nodeName
@@ -73,17 +80,76 @@ class ScormLib
                 if (is_null($organization)) {
                     \Log::error('parseOrganizationsNode: Default organization not found: ' . $defaultOrganization);
                     throw new InvalidScormArchiveException('default_organization_not_found_message');
-                } else {
-                    \Log::info('parseOrganizationsNode: Found default organization, proceeding with parseItemNodes');
                 }
             }
 
-            \Log::info('parseOrganizationsNode: Calling parseItemNodes');
-            return $this->parseItemNodes($organization, $resources);
+            $parsedItems = $this->parseItemNodes($organization, $resources);
+
+            // ENHANCEMENT: Handle single SCO with multiple resources scenario
+            if (count($parsedItems) === 1 && $this->countScoResources($resources) > 1) {
+                \Log::info('parseOrganizationsNode: Single item found but multiple SCO resources detected, enhancing structure');
+                return $this->enhanceWithAdditionalResources($parsedItems, $resources);
+            }
+
+            // Handle empty organization with resources
+            if (empty($parsedItems) && $this->countScoResources($resources) > 0) {
+                \Log::info('parseOrganizationsNode: Empty organization but SCO resources found, creating structure from resources');
+                return $this->parseResourceNodesWithStructure($resources);
+            }
+
+            return $parsedItems;
         } else {
             \Log::error('parseOrganizationsNode: No organizations found in manifest');
             throw new InvalidScormArchiveException('no_organization_found_message');
         }
+    }
+
+    /**
+     * Detect SCORM version from manifest
+     */
+    private function detectScormVersion(DOMDocument $dom)
+    {
+        $manifestNode = $dom->documentElement;
+
+        // Check schema location or version attributes
+        $schemaLocation = $manifestNode->getAttribute('xsi:schemaLocation');
+        $version = $manifestNode->getAttribute('version');
+
+        if (strpos($schemaLocation, '2004') !== false || strpos($schemaLocation, 'v1p3') !== false) {
+            if (strpos($schemaLocation, '4th') !== false || strpos($schemaLocation, 'CAM_v1p1') !== false) {
+                $this->scormVersion = '2004_4th';
+            } else if (strpos($schemaLocation, '3rd') !== false) {
+                $this->scormVersion = '2004_3rd';
+            } else {
+                $this->scormVersion = '2004_2nd';
+            }
+        } else if (strpos($schemaLocation, '1.2') !== false || strpos($schemaLocation, 'v1p2') !== false) {
+            $this->scormVersion = '1.2';
+        } else if ($version === '1.2') {
+            $this->scormVersion = '1.2';
+        } else {
+            // Default assumption based on common patterns
+            $adlcpNodes = $dom->getElementsByTagNameNS(self::ADLCP_V1P3_NAMESPACE, '*');
+            $this->scormVersion = $adlcpNodes->length > 0 ? '2004' : '1.2';
+        }
+
+        \Log::info('detectScormVersion: Detected SCORM version: ' . $this->scormVersion);
+    }
+
+    /**
+     * Extract namespaces from manifest
+     */
+    private function extractNamespaces(DOMDocument $dom)
+    {
+        $manifestNode = $dom->documentElement;
+        $xpath = new \DOMXPath($dom);
+
+        // Get all namespace declarations
+        foreach ($xpath->query('namespace::*', $manifestNode) as $node) {
+            $this->namespaces[$node->localName] = $node->nodeValue;
+        }
+
+        \Log::info('extractNamespaces: Found namespaces: ' . json_encode($this->namespaces));
     }
 
     /**
@@ -99,112 +165,607 @@ class ScormLib
         $scos = [];
         $itemCount = 0;
 
-        \Log::info('parseItemNodes: Starting to parse items from organization');
-
         while (!is_null($item)) {
             if ('item' === $item->nodeName) {
                 $itemCount++;
-                \Log::info("parseItemNodes: Processing item #{$itemCount}");
-                
+
                 $sco = new Sco();
                 $scos[] = $sco;
                 $sco->setUuid(Str::uuid());
                 $sco->setScoParent($parentSco);
-                
-                \Log::info("parseItemNodes: Created SCO #{$itemCount} with UUID: " . $sco->getUuid());
-                
+
                 $this->findAttrParams($sco, $item, $resources);
                 $this->findNodeParams($sco, $item->firstChild);
 
-                \Log::info("parseItemNodes: SCO #{$itemCount} - identifier: " . $sco->getIdentifier() . ", title: " . $sco->getTitle() . ", isBlock: " . ($sco->isBlock() ? 'true' : 'false'));
+                // Parse SCORM 2004 sequencing information
+                if ($this->isScorm2004()) {
+                    $this->parseSequencingInfo($sco, $item);
+                }
 
                 if ($sco->isBlock()) {
-                    \Log::info("parseItemNodes: SCO #{$itemCount} is a block, parsing children...");
                     $children = $this->parseItemNodes($item, $resources, $sco);
                     $sco->setScoChildren($children);
-                    \Log::info("parseItemNodes: SCO #{$itemCount} has " . count($children) . " children");
                 } else {
-                    \Log::info("parseItemNodes: SCO #{$itemCount} is not a block, entryUrl: " . $sco->getEntryUrl());
+                    // Check for sub-resources that might belong to this SCO
+                    $this->attachSubResources($sco, $resources);
                 }
             }
             $item = $item->nextSibling;
         }
 
-        \Log::info("parseItemNodes: Finished parsing, found {$itemCount} items, returning " . count($scos) . " SCOs");
+        \Log::info("parseItemNodes: Found {$itemCount} items, returning " . count($scos) . " SCOs");
         return $scos;
     }
 
-    private function parseResourceNodes(\DOMNodeList $resources)
+    /**
+     * Enhanced resource parsing that attempts to create logical structure
+     */
+    private function parseResourceNodesWithStructure(\DOMNodeList $resources)
     {
         $scos = [];
-        \Log::info('parseResourceNodes: Starting to parse ' . $resources->length . ' resources');
+        $scoResources = [];
+        $assetResources = [];
 
-        foreach ($resources as $index => $resource) {
-            \Log::info("parseResourceNodes: Processing resource #{$index}");
+        \Log::info('parseResourceNodesWithStructure: Parsing ' . $resources->length . ' resources for SCORM ' . $this->scormVersion);
 
+        // First, categorize resources
+        foreach ($resources as $resource) {
             if (!is_null($resource->attributes)) {
-                \Log::info("parseResourceNodes: Resource #{$index} has attributes");
-                
-                // Try to get the adlcp namespace URI
-                $adlcpNamespaceUri = $resource->lookupNamespaceUri('adlcp');
-                \Log::info("parseResourceNodes: Resource #{$index} adlcp namespace URI: " . ($adlcpNamespaceUri ?: 'null'));
-                
-                // If adlcp namespace is not found, try common SCORM namespaces
-                if (empty($adlcpNamespaceUri)) {
-                    $adlcpNamespaceUri = 'http://www.adlnet.org/xsd/adlcp_v1p3';
-                    \Log::info("parseResourceNodes: Using fallback adlcp namespace URI: {$adlcpNamespaceUri}");
-                }
-                
-                $scormType = null;
-                if (!empty($adlcpNamespaceUri)) {
-                    $scormType = $resource->attributes->getNamedItemNS($adlcpNamespaceUri, 'scormType');
-                    \Log::info("parseResourceNodes: Resource #{$index} scormType with namespace: " . ($scormType ? $scormType->nodeValue : 'null'));
-                }
+                $resourceType = $this->getResourceType($resource);
+                $identifier = $resource->attributes->getNamedItem('identifier');
+                $href = $resource->attributes->getNamedItem('href');
 
-                // If still no scormType found, try without namespace (for SCORM 1.2)
-                if (is_null($scormType)) {
-                    $scormType = $resource->attributes->getNamedItem('scormType');
-                    \Log::info("parseResourceNodes: Resource #{$index} scormType without namespace: " . ($scormType ? $scormType->nodeValue : 'null'));
+                \Log::debug('parseResourceNodesWithStructure: Resource', [
+                    'identifier' => $identifier ? $identifier->nodeValue : 'null',
+                    'href' => $href ? $href->nodeValue : 'null',
+                    'type' => $resourceType
+                ]);
+
+                if ($resourceType === 'sco' && !is_null($identifier) && !is_null($href)) {
+                    $scoResources[] = $resource;
+                } elseif (!is_null($href)) {
+                    $assetResources[] = $resource;
                 }
-
-                if (!is_null($scormType) && 'sco' === $scormType->nodeValue) {
-                    \Log::info("parseResourceNodes: Resource #{$index} is a SCO, processing...");
-                    
-                    $identifier = $resource->attributes->getNamedItem('identifier');
-                    $href = $resource->attributes->getNamedItem('href');
-
-                    \Log::info("parseResourceNodes: Resource #{$index} identifier: " . ($identifier ? $identifier->nodeValue : 'null'));
-                    \Log::info("parseResourceNodes: Resource #{$index} href: " . ($href ? $href->nodeValue : 'null'));
-
-                    if (is_null($identifier)) {
-                        \Log::error("parseResourceNodes: Resource #{$index} has no identifier");
-                        throw new InvalidScormArchiveException('sco_with_no_identifier_message');
-                    }
-                    if (is_null($href)) {
-                        \Log::error("parseResourceNodes: Resource #{$index} has no href");
-                        throw new InvalidScormArchiveException('sco_resource_without_href_message');
-                    }
-                    
-                    $sco = new Sco();
-                    $sco->setUuid(Str::uuid());
-                    $sco->setBlock(false);
-                    $sco->setVisible(true);
-                    $sco->setIdentifier($identifier->nodeValue);
-                    $sco->setTitle($identifier->nodeValue);
-                    $sco->setEntryUrl($href->nodeValue);
-                    $scos[] = $sco;
-                    
-                    \Log::info("parseResourceNodes: Successfully created SCO #{$index} with UUID: " . $sco->getUuid() . ", identifier: " . $sco->getIdentifier());
-                } else {
-                    \Log::info("parseResourceNodes: Resource #{$index} is not a SCO (scormType: " . ($scormType ? $scormType->nodeValue : 'null') . ")");
-                }
-            } else {
-                \Log::info("parseResourceNodes: Resource #{$index} has no attributes");
             }
         }
 
-        \Log::info('parseResourceNodes: Finished parsing, found ' . count($scos) . ' SCOs');
+        // Create SCOs from SCO resources
+        foreach ($scoResources as $resource) {
+            $sco = $this->createScoFromResource($resource);
+            if ($sco) {
+                $scos[] = $sco;
+            }
+        }
+
+        // If we have multiple SCOs, try to establish relationships
+        if (count($scos) > 1) {
+            $scos = $this->establishScoRelationships($scos, $assetResources);
+        }
+
+        \Log::info('parseResourceNodesWithStructure: Found ' . count($scos) . ' SCOs');
         return $scos;
+    }
+
+    /**
+     * Check if current SCORM version is 2004 family
+     */
+    private function isScorm2004()
+    {
+        return strpos($this->scormVersion, '2004') !== false;
+    }
+
+    /**
+     * Parse SCORM 2004 sequencing information
+     */
+    private function parseSequencingInfo(Sco $sco, \DOMNode $item)
+    {
+        // Look for imsss:sequencing nodes
+        $sequencingNodes = [];
+        $child = $item->firstChild;
+
+        while (!is_null($child)) {
+            if ($child->nodeName === 'imsss:sequencing' || $child->nodeName === 'sequencing') {
+                $sequencingNodes[] = $child;
+            }
+            $child = $child->nextSibling;
+        }
+
+        foreach ($sequencingNodes as $sequencingNode) {
+            $this->parseSequencingNode($sco, $sequencingNode);
+        }
+    }
+
+    /**
+     * Parse individual sequencing node
+     */
+    private function parseSequencingNode(Sco $sco, \DOMNode $sequencingNode)
+    {
+        $child = $sequencingNode->firstChild;
+
+        while (!is_null($child)) {
+            switch ($child->nodeName) {
+                case 'imsss:controlMode':
+                case 'controlMode':
+                    $this->parseControlMode($sco, $child);
+                    break;
+                case 'imsss:sequencingRules':
+                case 'sequencingRules':
+                    $this->parseSequencingRules($sco, $child);
+                    break;
+                case 'imsss:deliveryControls':
+                case 'deliveryControls':
+                    $this->parseDeliveryControls($sco, $child);
+                    break;
+                case 'imsss:objectives':
+                case 'objectives':
+                    $this->parseObjectives($sco, $child);
+                    break;
+            }
+            $child = $child->nextSibling;
+        }
+    }
+
+    /**
+     * Parse control mode settings
+     */
+    private function parseControlMode(Sco $sco, \DOMNode $controlMode)
+    {
+        $attributes = $controlMode->attributes;
+        if ($attributes) {
+            $choice = $attributes->getNamedItem('choice');
+            $flow = $attributes->getNamedItem('flow');
+
+            // Store sequencing information (you may need to add these methods to Sco entity)
+            if (method_exists($sco, 'setChoiceEnabled') && $choice) {
+                $sco->setChoiceEnabled($choice->nodeValue === 'true');
+            }
+            if (method_exists($sco, 'setFlowEnabled') && $flow) {
+                $sco->setFlowEnabled($flow->nodeValue === 'true');
+            }
+        }
+    }
+
+    /**
+     * Parse sequencing rules
+     */
+    private function parseSequencingRules(Sco $sco, \DOMNode $sequencingRules)
+    {
+        // Implementation depends on your Sco entity capabilities
+        // This is where you'd parse pre/post conditions, exit/retry rules, etc.
+    }
+
+    /**
+     * Parse delivery controls
+     */
+    private function parseDeliveryControls(Sco $sco, \DOMNode $deliveryControls)
+    {
+        $attributes = $deliveryControls->attributes;
+        if ($attributes) {
+            $tracked = $attributes->getNamedItem('tracked');
+            $completionSetByContent = $attributes->getNamedItem('completionSetByContent');
+
+            if (method_exists($sco, 'setTracked') && $tracked) {
+                $sco->setTracked($tracked->nodeValue === 'true');
+            }
+            if (method_exists($sco, 'setCompletionSetByContent') && $completionSetByContent) {
+                $sco->setCompletionSetByContent($completionSetByContent->nodeValue === 'true');
+            }
+        }
+    }
+
+    /**
+     * Parse objectives
+     */
+    private function parseObjectives(Sco $sco, \DOMNode $objectives)
+    {
+        // Parse primary and secondary objectives
+        // Implementation depends on your requirements
+    }
+
+    /**
+     * Count the number of SCO type resources
+     */
+    private function countScoResources(\DOMNodeList $resources)
+    {
+        $count = 0;
+        foreach ($resources as $resource) {
+            if ($this->getResourceType($resource) === 'sco') {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    /**
+     * Get resource type with proper SCORM version handling
+     */
+    private function getResourceType(\DOMNode $resource)
+    {
+        $scormType = null;
+
+        if ($this->scormVersion === '1.2') {
+            // SCORM 1.2 uses adlcp:scormtype attribute without namespace
+            $scormType = $resource->attributes->getNamedItem('scormtype');
+            if (is_null($scormType)) {
+                $scormType = $resource->attributes->getNamedItem('adlcp:scormtype');
+            }
+        } else {
+            // SCORM 2004 uses adlcp:scormType with namespace
+            $namespaces = [
+                self::ADLCP_V1P3_NAMESPACE,
+                self::ADLCP_V1P2_NAMESPACE
+            ];
+
+            foreach ($namespaces as $namespace) {
+                $scormType = $resource->attributes->getNamedItemNS($namespace, 'scormType');
+                if (!is_null($scormType)) {
+                    break;
+                }
+            }
+
+            // Fallback to non-namespaced attribute
+            if (is_null($scormType)) {
+                $scormType = $resource->attributes->getNamedItem('scormType');
+                if (is_null($scormType)) {
+                    $scormType = $resource->attributes->getNamedItem('adlcp:scormType');
+                }
+            }
+        }
+
+        $type = $scormType ? strtolower($scormType->nodeValue) : 'asset';
+
+        // Handle different type variations
+        switch ($type) {
+            case 'sco':
+                return 'sco';
+            case 'asset':
+                return 'asset';
+            default:
+                // Check if it has launchable content
+                $href = $resource->attributes->getNamedItem('href');
+                if ($href && $this->isLaunchableContent($href->nodeValue)) {
+                    return 'sco';
+                }
+                return 'asset';
+        }
+    }
+
+    /**
+     * Check if content is launchable (HTML, etc.)
+     */
+    private function isLaunchableContent($href)
+    {
+        $extension = strtolower(pathinfo($href, PATHINFO_EXTENSION));
+        $launchableExtensions = ['html', 'htm', 'xhtml', 'xml'];
+
+        return in_array($extension, $launchableExtensions);
+    }
+
+    /**
+     * Enhance existing SCOs with additional resources that might be related
+     */
+    private function enhanceWithAdditionalResources(array $scos, \DOMNodeList $resources)
+    {
+        if (empty($scos)) {
+            return $scos;
+        }
+
+        $mainSco = $scos[0];
+        $usedResourceIds = [];
+
+        // Collect already used resource IDs
+        foreach ($scos as $sco) {
+            if ($sco->getEntryUrl()) {
+                $resourceId = $this->findResourceIdByUrl($sco->getEntryUrl(), $resources);
+                if ($resourceId) {
+                    $usedResourceIds[] = $resourceId;
+                }
+            }
+        }
+
+        // Find additional SCO resources
+        $additionalScos = [];
+        foreach ($resources as $resource) {
+            if ($this->getResourceType($resource) === 'sco') {
+                $identifier = $resource->attributes->getNamedItem('identifier');
+                if ($identifier && !in_array($identifier->nodeValue, $usedResourceIds)) {
+                    $additionalSco = $this->createScoFromResource($resource);
+                    if ($additionalSco) {
+                        $additionalSco->setScoParent($mainSco);
+                        $additionalScos[] = $additionalSco;
+                    }
+                }
+            }
+        }
+
+        if (!empty($additionalScos)) {
+            if ($mainSco->isBlock()) {
+                $existingChildren = $mainSco->getScoChildren() ?: [];
+                $mainSco->setScoChildren(array_merge($existingChildren, $additionalScos));
+            } else {
+                // Convert main SCO to a block and add children
+                $mainSco->setBlock(true);
+                $mainSco->setScoChildren($additionalScos);
+                $mainSco->setEntryUrl(null); // Blocks don't have entry URLs
+            }
+        }
+
+        return $scos;
+    }
+
+    /**
+     * Attach related sub-resources to a SCO
+     */
+    private function attachSubResources(Sco $sco, \DOMNodeList $resources)
+    {
+        if ($sco->isBlock()) {
+            return; // Blocks don't have direct resources
+        }
+
+        $scoIdentifier = $sco->getIdentifier();
+        $relatedResources = [];
+
+        foreach ($resources as $resource) {
+            $resourceType = $this->getResourceType($resource);
+            if ($resourceType === 'sco') {
+                $identifier = $resource->attributes->getNamedItem('identifier');
+                $href = $resource->attributes->getNamedItem('href');
+
+                if ($identifier && $href && $identifier->nodeValue !== $scoIdentifier) {
+                    // Look for resources that might be related to this SCO
+                    if ($this->areResourcesRelated($scoIdentifier, $identifier->nodeValue)) {
+                        $childSco = $this->createScoFromResource($resource);
+                        if ($childSco) {
+                            $childSco->setScoParent($sco);
+                            $relatedResources[] = $childSco;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!empty($relatedResources)) {
+            $existingChildren = $sco->getScoChildren() ?: [];
+            $sco->setScoChildren(array_merge($existingChildren, $relatedResources));
+        }
+    }
+
+    /**
+     * Check if two resources are related
+     */
+    private function areResourcesRelated($identifier1, $identifier2)
+    {
+        // Implement heuristics to determine if resources are related
+        $id1Lower = strtolower($identifier1);
+        $id2Lower = strtolower($identifier2);
+
+        // Check for common patterns
+        $patterns = [
+            // One contains the other
+            strpos($id1Lower, $id2Lower) !== false,
+            strpos($id2Lower, $id1Lower) !== false,
+            // Common prefixes (first 3+ characters)
+            strlen($identifier1) > 3 && strlen($identifier2) > 3 &&
+                substr($id1Lower, 0, 3) === substr($id2Lower, 0, 3),
+            // Sequential numbering
+            preg_match('/\d+$/', $identifier1) && preg_match('/\d+$/', $identifier2) &&
+                preg_replace('/\d+$/', '', $id1Lower) === preg_replace('/\d+$/', '', $id2Lower)
+        ];
+
+        return in_array(true, $patterns, true);
+    }
+
+    /**
+     * Create a SCO from a resource node
+     */
+    private function createScoFromResource(\DOMNode $resource)
+    {
+        $identifier = $resource->attributes->getNamedItem('identifier');
+        $href = $resource->attributes->getNamedItem('href');
+
+        if (is_null($identifier)) {
+            \Log::error("createScoFromResource: SCO has no identifier");
+            return null;
+        }
+        if (is_null($href)) {
+            \Log::error("createScoFromResource: SCO has no href");
+            return null;
+        }
+
+        $sco = new Sco();
+        $sco->setUuid(Str::uuid());
+        $sco->setBlock(false);
+        $sco->setVisible(true);
+        $sco->setIdentifier($identifier->nodeValue);
+        $sco->setEntryUrl($href->nodeValue);
+
+        // Extract additional parameters
+        $this->extractResourceParameters($sco, $resource);
+
+        // Try to get title from resource metadata
+        $title = $this->extractTitleFromResource($resource);
+        $sco->setTitle($title ?: $identifier->nodeValue);
+
+        \Log::info("createScoFromResource: Created SCO - " . $sco->getIdentifier());
+        return $sco;
+    }
+
+    /**
+     * Extract parameters from resource node
+     */
+    private function extractResourceParameters(Sco $sco, \DOMNode $resource)
+    {
+        $attributes = $resource->attributes;
+        if (!$attributes) {
+            return;
+        }
+
+        // Extract parameters attribute
+        $parameters = $attributes->getNamedItem('parameters');
+        if ($parameters) {
+            $sco->setParameters($parameters->nodeValue);
+        }
+
+        // Extract other resource-level metadata
+        $child = $resource->firstChild;
+        while (!is_null($child)) {
+            if ($child->nodeName === 'file') {
+                // Process file dependencies if needed
+            } elseif ($child->nodeName === 'metadata') {
+                $this->parseResourceMetadata($sco, $child);
+            }
+            $child = $child->nextSibling;
+        }
+    }
+
+    /**
+     * Parse resource metadata
+     */
+    private function parseResourceMetadata(Sco $sco, \DOMNode $metadata)
+    {
+        // Parse LOM metadata or other metadata formats
+        // Implementation depends on your metadata requirements
+    }
+
+    /**
+     * Extract title from resource
+     */
+    private function extractTitleFromResource(\DOMNode $resource)
+    {
+        // Look in metadata
+        $metadataNodes = [];
+        $child = $resource->firstChild;
+
+        while (!is_null($child)) {
+            if ($child->nodeName === 'metadata') {
+                $metadataNodes[] = $child;
+            }
+            $child = $child->nextSibling;
+        }
+
+        foreach ($metadataNodes as $metadata) {
+            $title = $this->findTitleInMetadata($metadata);
+            if ($title) {
+                return $title;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find title in metadata node
+     */
+    private function findTitleInMetadata(\DOMNode $metadata)
+    {
+        $xpath = new \DOMXPath($metadata->ownerDocument);
+
+        // Try different title paths
+        $titlePaths = [
+            './/lom:title/lom:langstring',
+            './/title/langstring',
+            './/title',
+            './/dc:title'
+        ];
+
+        foreach ($titlePaths as $path) {
+            $titles = $xpath->query($path, $metadata);
+            if ($titles && $titles->length > 0) {
+                return trim($titles->item(0)->nodeValue);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find resource ID by URL
+     */
+    private function findResourceIdByUrl($url, \DOMNodeList $resources)
+    {
+        foreach ($resources as $resource) {
+            $href = $resource->attributes->getNamedItem('href');
+            if ($href && $href->nodeValue === $url) {
+                $identifier = $resource->attributes->getNamedItem('identifier');
+                return $identifier ? $identifier->nodeValue : null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Attempt to establish relationships between SCOs
+     */
+    private function establishScoRelationships(array $scos, array $assetResources)
+    {
+        if (count($scos) <= 1) {
+            return $scos;
+        }
+
+        // Try to identify a logical parent-child structure
+        $parentSco = $this->findParentSco($scos);
+
+        if ($parentSco) {
+            $childScos = array_filter($scos, function ($sco) use ($parentSco) {
+                return $sco !== $parentSco;
+            });
+
+            if (!empty($childScos)) {
+                $parentSco->setBlock(true);
+                $parentSco->setEntryUrl(null); // Blocks don't have entry URLs
+
+                foreach ($childScos as $childSco) {
+                    $childSco->setScoParent($parentSco);
+                }
+
+                $parentSco->setScoChildren($childScos);
+                return [$parentSco];
+            }
+        }
+
+        // If no clear structure, return all as siblings
+        return $scos;
+    }
+
+    /**
+     * Find the most likely parent SCO
+     */
+    private function findParentSco(array $scos)
+    {
+        $scores = [];
+
+        foreach ($scos as $sco) {
+            $score = 0;
+            $identifier = strtolower($sco->getIdentifier());
+            $entryUrl = strtolower($sco->getEntryUrl() ?: '');
+
+            // Score based on common parent indicators
+            if (strpos($identifier, 'main') !== false) $score += 10;
+            if (strpos($identifier, 'index') !== false) $score += 8;
+            if (strpos($identifier, 'intro') !== false) $score += 6;
+            if (strpos($identifier, 'menu') !== false) $score += 5;
+            if (strpos($identifier, 'toc') !== false) $score += 5;
+            if (strpos($entryUrl, 'index') !== false) $score += 4;
+            if (strpos($entryUrl, 'main') !== false) $score += 4;
+
+            // Lower scores for obviously child-like names
+            if (strpos($identifier, 'lesson') !== false) $score -= 2;
+            if (strpos($identifier, 'page') !== false) $score -= 2;
+            if (preg_match('/\d+/', $identifier)) $score -= 1;
+
+            $scores[$sco->getIdentifier()] = $score;
+        }
+
+        // Return SCO with highest score
+        $maxScore = max($scores);
+        if ($maxScore > 0) {
+            $parentId = array_search($maxScore, $scores);
+            return array_filter($scos, function ($sco) use ($parentId) {
+                return $sco->getIdentifier() === $parentId;
+            })[0] ?? null;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Library/ScormLib.php
+++ b/src/Library/ScormLib.php
@@ -936,7 +936,10 @@ class ScormLib
                 foreach ($fileElements as $file) {
                     $href = $file->attributes->getNamedItem('href');
                     if (!is_null($href) && preg_match('/\.html$/i', $href->nodeValue)) {
-                        $htmlFiles[] = $href->nodeValue;
+                        // Skip index.html as it's the main entry point
+                        if (strtolower($href->nodeValue) !== 'index.html') {
+                            $htmlFiles[] = $href->nodeValue;
+                        }
                     }
                 }
                 break;

--- a/src/Manager/LocalUnzipper.php
+++ b/src/Manager/LocalUnzipper.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Peopleaps\Scorm\Manager;
+
+use Exception;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Log;
+use Peopleaps\Scorm\Contract\UnzipperInterface;
+use Peopleaps\Scorm\Exception\StorageNotFoundException;
+use ZipArchive;
+
+/**
+ * Extracts a SCORM zip from the archive disk to the scorm disk via a local
+ * temp file and PHP's built-in ZipArchive.
+ */
+class LocalUnzipper implements UnzipperInterface
+{
+    public function __construct(
+        private readonly FilesystemAdapter $archiveDisk,
+        private readonly FilesystemAdapter $scormDisk,
+    ) {}
+
+    /** {@inheritdoc} */
+    public function extract(string $archiveKey, string $targetUuid): void
+    {
+        if (!$this->archiveDisk->exists($archiveKey)) {
+            throw new StorageNotFoundException('scorm_archive_not_found: ' . $archiveKey);
+        }
+
+        $stream = $this->archiveDisk->readStream($archiveKey);
+        if (!is_resource($stream)) {
+            throw new StorageNotFoundException('failed_to_read_scorm_archive_stream: ' . $archiveKey);
+        }
+
+        $tmpPath = $this->writeStreamToTempFile($stream);
+
+        try {
+            $this->unzipToScormDisk($tmpPath, $targetUuid);
+        } finally {
+            @unlink($tmpPath);
+        }
+    }
+
+    /** @param resource $stream */
+    private function writeStreamToTempFile($stream): string
+    {
+        $tmpPath = tempnam(sys_get_temp_dir(), 'scorm_');
+        if ($tmpPath === false) {
+            throw new Exception('Could not create temporary file.');
+        }
+
+        $handle = fopen($tmpPath, 'wb');
+        if ($handle === false) {
+            unlink($tmpPath);
+            throw new Exception('Could not open temporary file for writing: ' . $tmpPath);
+        }
+
+        try {
+            stream_copy_to_stream($stream, $handle);
+        } finally {
+            fclose($handle);
+            fclose($stream);
+        }
+
+        return $tmpPath;
+    }
+
+    private function unzipToScormDisk(string $zipPath, string $targetUuid): void
+    {
+        $prefix = $this->normalizeKey($targetUuid);
+        $zip    = new ZipArchive();
+
+        if ($zip->open($zipPath) !== true) {
+            throw new StorageNotFoundException('zip_open_failed: ' . $zipPath);
+        }
+
+        try {
+            for ($i = 0; $i < $zip->numFiles; ++$i) {
+                $name        = $zip->getNameIndex($i);
+                $destination = $this->joinPath($prefix, $this->normalizeKey($name));
+
+                if (str_ends_with($name, '/')) {
+                    $this->scormDisk->createDirectory($destination);
+                    continue;
+                }
+
+                $stream = $zip->getStream($name);
+                if (!is_resource($stream)) {
+                    Log::warning('LocalUnzipper: could not open stream for zip entry: ' . $name);
+                    continue;
+                }
+
+                $this->scormDisk->writeStream($destination, $stream);
+                fclose($stream);
+            }
+        } finally {
+            $zip->close();
+        }
+    }
+
+    private function joinPath(string ...$segments): string
+    {
+        return implode('/', array_filter($segments, fn($s) => $s !== ''));
+    }
+
+    private function normalizeKey(string $path): string
+    {
+        return rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $path), '/');
+    }
+}

--- a/src/Manager/ScormDisk.php
+++ b/src/Manager/ScormDisk.php
@@ -2,275 +2,270 @@
 
 namespace Peopleaps\Scorm\Manager;
 
+use DateTime;
+use DOMDocument;
 use Exception;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Peopleaps\Scorm\Contract\UnzipperInterface;
+use Peopleaps\Scorm\Entity\Scorm;
+use Peopleaps\Scorm\Exception\InvalidScormArchiveException;
 use Peopleaps\Scorm\Exception\StorageNotFoundException;
-use ZipArchive;
+use Peopleaps\Scorm\Library\ScormLib;
 
 class ScormDisk
 {
-    /**
-     * Extract a zip from the archive S3 bucket and stream each entry
-     * directly into the scorm S3 bucket — no local app-storage I/O.
-     *
-     * Strategy:
-     *   1. Stream the zip from archive-S3 into a PHP temporary file
-     *      (php://temp or sys_get_temp_dir). This is an OS-level tmp file
-     *      completely separate from Laravel's Storage / app disk.
-     *   2. Open the tmp file with ZipArchive (which requires a real path).
-     *   3. Stream every entry straight to the scorm S3 bucket.
-     *   4. Delete the tmp file immediately — it is never written to the
-     *      Laravel default disk or app storage directory.
-     *
-     * @param  UploadedFile|string  $file        Local path or UploadedFile for
-     *                                           an already-downloaded zip. Pass
-     *                                           null and use readScormArchive()
-     *                                           when the zip lives on S3.
-     * @param  string               $target_dir  S3 key prefix (folder) for output.
-     * @return bool
-     */
-    public function unzipper($file, string $target_dir): bool
-    {
-        $target_dir = $this->normalizeS3Key($target_dir);
+    private ScormLib $scormLib;
 
-        $zip = new ZipArchive();
-
-        if ($zip->open($file) !== true) {
-            Log::error('ScormDisk::unzipper — ZipArchive could not open file: ' . $file);
-            return false;
-        }
-
-        try {
-            /** @var FilesystemAdapter $disk */
-            $disk = $this->getDisk();
-
-            for ($i = 0; $i < $zip->numFiles; ++$i) {
-                $zipEntryName = $zip->getNameIndex($i);
-
-                // Normalise the entry name to a clean S3 key segment.
-                $entryKey = $this->normalizeS3Key($zipEntryName);
-                $destination = $this->joinS3($target_dir, $entryKey);
-
-                if ($this->isDirectory($zipEntryName)) {
-                    // S3 has no real directories; creating a zero-byte placeholder
-                    // is optional but kept for compatibility with code that checks
-                    // directory existence via $disk->directoryExists().
-                    $disk->createDirectory($destination);
-                    continue;
-                }
-
-                $stream = $zip->getStream($zipEntryName);
-                if (!is_resource($stream)) {
-                    Log::warning('ScormDisk::unzipper — could not get stream for entry: ' . $zipEntryName);
-                    continue;
-                }
-
-                // writeStream() passes the resource to the S3 SDK which may
-                // close it internally before returning. Guard before fclose.
-                $disk->writeStream($destination, $stream);
-                if (is_resource($stream)) {
-                    fclose($stream);
-                }
-            }
-        } finally {
-            $zip->close();
-        }
-
-        return true;
+    public function __construct(
+        private readonly UnzipperInterface $unzipper,
+        ?ScormLib $scormLib = null,
+    ) {
+        $this->scormLib = $scormLib ?? new ScormLib();
     }
 
     /**
-     * Read a SCORM zip from the archive S3 bucket, expose its local tmp path
-     * to $fn, then clean up — without writing to Laravel's app Storage disk.
-     *
-     * Flow:
-     *   archive-S3 ──stream──► php://temp (OS tmp, not app disk)
-     *                                │
-     *                           ZipArchive::open()
-     *                                │
-     *                         call $fn($tmpPath)  ← unzipper() is called here
-     *                                │
-     *                           unlink($tmpPath)
-     *
-     * @param  string    $file  S3 object key inside the archive bucket.
-     * @param  callable  $fn    Receives the real local tmp file path.
-     * @throws StorageNotFoundException|Exception
+     * Whether extracted SCORM content for the given UUID already exists on the
+     * scorm disk (detected by the presence of imsmanifest.xml).
      */
-    public function readScormArchive(string $file, callable $fn): void
+    public function contentExists(string $uuid): bool
     {
-        $archiveDisk = $this->getArchiveDisk();
+        $disk   = $this->getScormDisk();
+        $prefix = $this->normalizeKey($uuid);
 
-        Log::info('ScormDisk::readScormArchive — processing: ' . $file);
-
-        if (!$archiveDisk->exists($file)) {
-            Log::error('ScormDisk::readScormArchive — not found on archive disk: ' . $file);
-            throw new StorageNotFoundException('scorm_archive_not_found_on_archive_disk: ' . $file);
+        if ($disk->exists($prefix . '/imsmanifest.xml')) {
+            return true;
         }
 
-        // Pull the S3 object as a stream.
-        $s3Stream = $archiveDisk->readStream($file);
-        if (!is_resource($s3Stream)) {
-            Log::error('ScormDisk::readScormArchive — failed to open stream for: ' . $file);
-            throw new StorageNotFoundException('failed_to_read_scorm_archive_stream: ' . $file);
+        foreach ($disk->allFiles($prefix) as $path) {
+            if (str_ends_with($path, 'imsmanifest.xml')) {
+                return true;
+            }
         }
 
-        // Write into a true OS temp file (never touches app Storage disk).
-        $tmpPath = $this->streamToTempFile($s3Stream);
+        return false;
+    }
+
+    /**
+     * Parse imsmanifest.xml from the scorm disk for the given UUID and return
+     * structured metadata ready for persistence.
+     *
+     * @return array{
+     *   identifier: string,
+     *   title: string,
+     *   version: string,
+     *   entryUrl: string,
+     *   scos: \Peopleaps\Scorm\Entity\Sco[],
+     *   created_at: string|null,
+     *   created_by: string|null,
+     * }
+     * @throws InvalidScormArchiveException
+     */
+    public function loadMetadata(string $uuid): array
+    {
+        $disk         = $this->getScormDisk();
+        $prefix       = $this->normalizeKey($uuid);
+        $manifestPath = $this->findManifest($disk, $prefix);
+
+        if ($manifestPath === null) {
+            throw new InvalidScormArchiveException('cannot_load_imsmanifest_message');
+        }
+
+        $xml = $disk->get($manifestPath);
+        if (empty($xml)) {
+            throw new InvalidScormArchiveException('cannot_load_imsmanifest_message');
+        }
+
+        $dom = $this->parseManifestXml($xml);
+
+        $manifest = $dom->getElementsByTagName('manifest')->item(0);
+        if (!$manifest || !$manifest->attributes->getNamedItem('identifier')) {
+            throw new InvalidScormArchiveException('invalid_scorm_manifest_identifier');
+        }
+
+        $version = $this->resolveScormVersion($dom);
+        $scos    = $this->scormLib->parseOrganizationsNode($dom);
+
+        if (empty($scos)) {
+            throw new InvalidScormArchiveException('no_sco_in_scorm_archive_message');
+        }
+
+        $entryUrl = $scos[0]->entryUrl ?? $scos[0]->scoChildren[0]->entryUrl ?? '';
+        $entryUrl = $this->prefixEntryUrl($entryUrl, $manifestPath);
+
+        return [
+            'identifier' => $manifest->attributes->getNamedItem('identifier')->nodeValue,
+            'title'      => trim($dom->getElementsByTagName('title')->item(0)?->textContent ?? ''),
+            'version'    => $version,
+            'entryUrl'   => $entryUrl,
+            'scos'       => $scos,
+            'created_at' => $this->extractCreationDate($dom),
+            'created_by' => $this->extractCreator($dom),
+        ];
+    }
+
+    /**
+     * Delegate extraction of the archive at $archiveKey into the scorm disk
+     * under the $uuid prefix to the injected UnzipperInterface.
+     */
+    public function extractFromArchive(string $archiveKey, string $uuid): void
+    {
+        $this->unzipper->extract($archiveKey, $uuid);
+    }
+
+    /**
+     * Store an uploaded zip on the archive disk at the given key.
+     */
+    public function putArchiveFile(UploadedFile $file, string $archiveKey): void
+    {
+        $stream = fopen($file->getRealPath(), 'r');
+        if ($stream === false) {
+            throw new Exception('Could not open uploaded file: ' . $file->getClientOriginalName());
+        }
 
         try {
-            call_user_func($fn, $tmpPath);
+            $this->getArchiveDisk()->writeStream($archiveKey, $stream);
         } finally {
-            // Always clean up the tmp file, even if $fn throws.
-            if (file_exists($tmpPath)) {
-                unlink($tmpPath);
-                Log::info('ScormDisk::readScormArchive — removed tmp file: ' . $tmpPath);
-            }
+            fclose($stream);
         }
     }
 
     /**
-     * Delete both the content folder (scorm disk) and the archive folder
+     * Delete both the content directory (scorm disk) and the archive directory
      * (archive disk) for the given UUID.
      *
-     * @param  string  $uuid
-     * @return bool  true only when the content directory was removed.
+     * @return bool True when the content directory was successfully removed.
      */
     public function deleteScorm(string $uuid): bool
     {
-        $this->deleteScormArchive($uuid);
-        return $this->deleteScormContent($uuid);
+        $this->deleteDirectory($this->getArchiveDisk(), $uuid, 'archive');
+        return $this->deleteDirectory($this->getScormDisk(), $uuid, 'scorm');
     }
 
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------
 
-    /**
-     * Copy an S3 stream into a true OS temporary file and return its path.
-     * Uses sys_get_temp_dir() — completely separate from Laravel Storage.
-     *
-     * @param  resource  $stream
-     * @return string  Absolute path to the tmp file.
-     * @throws Exception
-     */
-    private function streamToTempFile($stream): string
+    private function normalizeKey(string $path): string
     {
-        $tmpPath = tempnam(sys_get_temp_dir(), 'scorm_');
-        if ($tmpPath === false) {
-            throw new Exception('ScormDisk — could not create OS temp file.');
-        }
-
-        $tmpHandle = fopen($tmpPath, 'wb');
-        if ($tmpHandle === false) {
-            unlink($tmpPath);
-            throw new Exception('ScormDisk — could not open OS temp file for writing: ' . $tmpPath);
-        }
-
-        try {
-            stream_copy_to_stream($stream, $tmpHandle);
-        } finally {
-            fclose($tmpHandle);
-            // The S3 SDK / Flysystem may close the stream internally during
-            // stream_copy_to_stream. Guard with is_resource before fclose to
-            // avoid "supplied resource is not a valid stream resource" errors.
-            if (is_resource($stream)) {
-                fclose($stream);
-            }
-        }
-
-        return $tmpPath;
-    }
-
-    /**
-     * Delete the SCORM content directory from the scorm S3 bucket.
-     */
-    private function deleteScormContent(string $folderHashedName): bool
-    {
-        try {
-            return (bool) $this->getDisk()->deleteDirectory($folderHashedName);
-        } catch (Exception $ex) {
-            Log::error('ScormDisk::deleteScormContent — ' . $ex->getMessage());
-            return false;
-        }
-    }
-
-    /**
-     * Delete the SCORM archive directory from the archive S3 bucket.
-     */
-    private function deleteScormArchive(string $uuid): bool
-    {
-        try {
-            return (bool) $this->getArchiveDisk()->deleteDirectory($uuid);
-        } catch (Exception $ex) {
-            Log::error('ScormDisk::deleteScormArchive — ' . $ex->getMessage());
-            return false;
-        }
-    }
-
-    /**
-     * Join path segments using '/' — always correct for S3 keys regardless
-     * of the host OS's DIRECTORY_SEPARATOR.
-     */
-    private function joinS3(string ...$paths): string
-    {
-        return implode('/', array_filter($paths, fn($p) => $p !== ''));
-    }
-
-    /**
-     * Normalise a path to use '/' (S3 convention).
-     * Strips a trailing slash so the result is always a key prefix, not
-     * a directory placeholder.
-     */
-    private function normalizeS3Key(string $path): string
-    {
-        // Convert OS separators → S3 separator, then strip trailing slash.
         return rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $path), '/');
     }
 
-    /**
-     * Returns true when the zip entry represents a directory.
-     */
-    private function isDirectory(string $zipEntryName): bool
+    private function findManifest(FilesystemAdapter $disk, string $prefix): ?string
     {
-        return str_ends_with($zipEntryName, '/');
+        $direct = $prefix . '/imsmanifest.xml';
+        if ($disk->exists($direct)) {
+            return $direct;
+        }
+
+        foreach ($disk->allFiles($prefix) as $path) {
+            if (str_ends_with($path, 'imsmanifest.xml')) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    private function parseManifestXml(string $xml): DOMDocument
+    {
+        // Escape bare ampersands that would otherwise break XML parsing.
+        $xml = preg_replace('/&(?!amp;|lt;|gt;|apos;|quot;)/', '&amp;', $xml) ?? $xml;
+
+        $dom = new DOMDocument();
+        if (!$dom->loadXML($xml)) {
+            throw new InvalidScormArchiveException('cannot_load_imsmanifest_message');
+        }
+
+        return $dom;
+    }
+
+    private function resolveScormVersion(DOMDocument $dom): string
+    {
+        $nodes = $dom->getElementsByTagName('schemaversion');
+        if ($nodes->length === 0) {
+            throw new InvalidScormArchiveException('invalid_scorm_version_message');
+        }
+
+        $version = trim($nodes->item(0)->textContent);
+
+        if ($version === '1.2') {
+            return Scorm::SCORM_12;
+        }
+
+        if (in_array($version, ['CAM 1.3', '2004 3rd Edition', '2004 4th Edition'], true)) {
+            return Scorm::SCORM_2004;
+        }
+
+        throw new InvalidScormArchiveException('invalid_scorm_version_message');
     }
 
     /**
-     * Resolve and validate the scorm content disk.
-     *
-     * @return FilesystemAdapter
-     * @throws StorageNotFoundException
+     * Prepend the manifest's directory to the entry URL when the manifest is
+     * nested inside a sub-folder (e.g. "content/imsmanifest.xml").
      */
-    private function getDisk(): FilesystemAdapter
+    private function prefixEntryUrl(string $entryUrl, string $manifestPath): string
     {
-        $diskName = config('scorm.disk');
-        if (empty($diskName)) {
-            throw new StorageNotFoundException('scorm_disk_not_configured');
+        $dir = dirname($manifestPath);
+
+        if ($dir === '' || $dir === '.') {
+            return $entryUrl;
         }
-        if (!config()->has('filesystems.disks.' . $diskName)) {
-            throw new StorageNotFoundException('scorm_disk_not_defined: ' . $diskName);
-        }
-        return Storage::disk($diskName);
+
+        return $dir . '/' . ltrim($entryUrl, '/');
     }
 
-    /**
-     * Resolve and validate the scorm archive disk.
-     *
-     * @return FilesystemAdapter
-     * @throws StorageNotFoundException
-     */
+    private function extractCreationDate(DOMDocument $dom): ?string
+    {
+        $raw = trim($dom->getElementsByTagName('datetime')->item(0)?->textContent ?? '');
+        if ($raw === '') {
+            return null;
+        }
+
+        try {
+            return (new DateTime($raw))->format('Y-m-d H:i:s');
+        } catch (Exception) {
+            return $raw;
+        }
+    }
+
+    private function extractCreator(DOMDocument $dom): ?string
+    {
+        $value = trim($dom->getElementsByTagName('creator')->item(0)?->textContent ?? '');
+        return $value !== '' ? $value : null;
+    }
+
+    private function deleteDirectory(FilesystemAdapter $disk, string $uuid, string $label): bool
+    {
+        try {
+            return (bool) $disk->deleteDirectory($uuid);
+        } catch (Exception $e) {
+            \Illuminate\Support\Facades\Log::error("ScormDisk: failed to delete {$label} directory for {$uuid}: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    private function getScormDisk(): FilesystemAdapter
+    {
+        return $this->resolveDisk(config('scorm.disk'), 'scorm_disk');
+    }
+
     private function getArchiveDisk(): FilesystemAdapter
     {
-        $archiveDiskName = config('scorm.archive');
-        if (empty($archiveDiskName)) {
-            throw new StorageNotFoundException('scorm_archive_disk_not_configured');
+        return $this->resolveDisk(config('scorm.archive'), 'scorm_archive_disk');
+    }
+
+    private function resolveDisk(?string $name, string $label): FilesystemAdapter
+    {
+        if (empty($name)) {
+            throw new StorageNotFoundException("{$label}_not_configured");
         }
-        if (!config()->has('filesystems.disks.' . $archiveDiskName)) {
-            throw new StorageNotFoundException('scorm_archive_disk_not_defined: ' . $archiveDiskName);
+
+        if (!config()->has('filesystems.disks.' . $name)) {
+            throw new StorageNotFoundException("{$label}_not_defined: {$name}");
         }
-        return Storage::disk($archiveDiskName);
+
+        return Storage::disk($name);
     }
 }

--- a/src/Manager/ScormDisk.php
+++ b/src/Manager/ScormDisk.php
@@ -8,179 +8,265 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Peopleaps\Scorm\Exception\StorageNotFoundException;
+use ZipArchive;
 
 class ScormDisk
 {
     /**
-     * Extract zip file into destination directory.
+     * Extract a zip from the archive S3 bucket and stream each entry
+     * directly into the scorm S3 bucket — no local app-storage I/O.
      *
-     * @param UploadedFile|string $file zip source
-     * @param string $path The path to the destination.
+     * Strategy:
+     *   1. Stream the zip from archive-S3 into a PHP temporary file
+     *      (php://temp or sys_get_temp_dir). This is an OS-level tmp file
+     *      completely separate from Laravel's Storage / app disk.
+     *   2. Open the tmp file with ZipArchive (which requires a real path).
+     *   3. Stream every entry straight to the scorm S3 bucket.
+     *   4. Delete the tmp file immediately — it is never written to the
+     *      Laravel default disk or app storage directory.
      *
-     * @return bool true on success, false on failure.
+     * @param  UploadedFile|string  $file        Local path or UploadedFile for
+     *                                           an already-downloaded zip. Pass
+     *                                           null and use readScormArchive()
+     *                                           when the zip lives on S3.
+     * @param  string               $target_dir  S3 key prefix (folder) for output.
+     * @return bool
      */
-    function unzipper($file, $target_dir)
+    public function unzipper($file, string $target_dir): bool
     {
-        $target_dir = $this->cleanPath($target_dir);
-        $unzipper = resolve(\ZipArchive::class);
-        if ($unzipper->open($file)) {
+        $target_dir = $this->normalizeS3Key($target_dir);
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($file) !== true) {
+            Log::error('ScormDisk::unzipper — ZipArchive could not open file: ' . $file);
+            return false;
+        }
+
+        try {
             /** @var FilesystemAdapter $disk */
             $disk = $this->getDisk();
-            for ($i = 0; $i < $unzipper->numFiles; ++$i) {
-                $zipEntryName = $unzipper->getNameIndex($i);
-                $destination = $this->join($target_dir, $this->cleanPath($zipEntryName));
+
+            for ($i = 0; $i < $zip->numFiles; ++$i) {
+                $zipEntryName = $zip->getNameIndex($i);
+
+                // Normalise the entry name to a clean S3 key segment.
+                $entryKey = $this->normalizeS3Key($zipEntryName);
+                $destination = $this->joinS3($target_dir, $entryKey);
+
                 if ($this->isDirectory($zipEntryName)) {
+                    // S3 has no real directories; creating a zero-byte placeholder
+                    // is optional but kept for compatibility with code that checks
+                    // directory existence via $disk->directoryExists().
                     $disk->createDirectory($destination);
                     continue;
                 }
-                $disk->writeStream($destination, $unzipper->getStream($zipEntryName));
+
+                $stream = $zip->getStream($zipEntryName);
+                if (!is_resource($stream)) {
+                    Log::warning('ScormDisk::unzipper — could not get stream for entry: ' . $zipEntryName);
+                    continue;
+                }
+
+                // writeStream() hands the resource straight to the S3 SDK —
+                // no intermediate local write.
+                $disk->writeStream($destination, $stream);
+                fclose($stream);
             }
-            return true;
+        } finally {
+            $zip->close();
         }
-        return false;
+
+        return true;
     }
 
     /**
-     * @param string $file SCORM archive uri on storage.
-     * @param callable $fn function run user stuff before unlink
+     * Read a SCORM zip from the archive S3 bucket, expose its local tmp path
+     * to $fn, then clean up — without writing to Laravel's app Storage disk.
+     *
+     * Flow:
+     *   archive-S3 ──stream──► php://temp (OS tmp, not app disk)
+     *                                │
+     *                           ZipArchive::open()
+     *                                │
+     *                         call $fn($tmpPath)  ← unzipper() is called here
+     *                                │
+     *                           unlink($tmpPath)
+     *
+     * @param  string    $file  S3 object key inside the archive bucket.
+     * @param  callable  $fn    Receives the real local tmp file path.
+     * @throws StorageNotFoundException|Exception
      */
-    public function readScormArchive($file, callable $fn)
+    public function readScormArchive(string $file, callable $fn): void
     {
-        try {
-            $archiveDisk = $this->getArchiveDisk();
+        $archiveDisk = $this->getArchiveDisk();
 
-            // Log the file path being processed for debugging
-            Log::info('Processing SCORM archive file: ' . $file);
+        Log::info('ScormDisk::readScormArchive — processing: ' . $file);
 
-            // Check if file exists on archive disk
-            if (!$archiveDisk->exists($file)) {
-                Log::error('File not found on archive disk: ' . $file);
-                throw new StorageNotFoundException('scorm_archive_not_found_on_archive_disk: ' . $file);
-            }
-
-            // Get the stream from archive disk
-            $stream = $archiveDisk->readStream($file);
-            if (!is_resource($stream)) {
-                Log::error('Failed to read stream from archive disk for file: ' . $file . '. Stream type: ' . gettype($stream));
-                throw new StorageNotFoundException('failed_to_read_scorm_archive_stream: ' . $file);
-            }
-
-            if (Storage::exists($file)) {
-                Storage::delete($file);
-            }
-
-            Storage::writeStream($file, $stream);
-            $path = Storage::path($file);
-            call_user_func($fn, $path);
-            // Clean local resources
-            $this->clean($file);
-        } catch (Exception $ex) {
-            Log::error('Error in readScormArchive: ' . $ex->getMessage() . ' for file: ' . $file);
-            throw $ex;
+        if (!$archiveDisk->exists($file)) {
+            Log::error('ScormDisk::readScormArchive — not found on archive disk: ' . $file);
+            throw new StorageNotFoundException('scorm_archive_not_found_on_archive_disk: ' . $file);
         }
-    }
 
-    private function clean($file)
-    {
+        // Pull the S3 object as a stream.
+        $s3Stream = $archiveDisk->readStream($file);
+        if (!is_resource($s3Stream)) {
+            Log::error('ScormDisk::readScormArchive — failed to open stream for: ' . $file);
+            throw new StorageNotFoundException('failed_to_read_scorm_archive_stream: ' . $file);
+        }
+
+        // Write into a true OS temp file (never touches app Storage disk).
+        $tmpPath = $this->streamToTempFile($s3Stream);
+
         try {
-            Storage::delete($file);
-            Storage::deleteDirectory(dirname($file)); // delete temp dir
-        } catch (Exception $ex) {
-            Log::error($ex->getMessage());
+            call_user_func($fn, $tmpPath);
+        } finally {
+            // Always clean up the tmp file, even if $fn throws.
+            if (file_exists($tmpPath)) {
+                unlink($tmpPath);
+                Log::info('ScormDisk::readScormArchive — removed tmp file: ' . $tmpPath);
+            }
         }
     }
 
     /**
-     * @param string $directory
-     * @return bool
+     * Delete both the content folder (scorm disk) and the archive folder
+     * (archive disk) for the given UUID.
+     *
+     * @param  string  $uuid
+     * @return bool  true only when the content directory was removed.
      */
-    public function deleteScorm($uuid)
+    public function deleteScorm(string $uuid): bool
     {
-        $this->deleteScormArchive($uuid); // try to delete archive if exists.
+        $this->deleteScormArchive($uuid);
         return $this->deleteScormContent($uuid);
     }
 
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
     /**
-     * @param string $directory
-     * @return bool
+     * Copy an S3 stream into a true OS temporary file and return its path.
+     * Uses sys_get_temp_dir() — completely separate from Laravel Storage.
+     *
+     * @param  resource  $stream
+     * @return string  Absolute path to the tmp file.
+     * @throws Exception
      */
-    private function deleteScormContent($folderHashedName)
+    private function streamToTempFile($stream): string
+    {
+        $tmpPath = tempnam(sys_get_temp_dir(), 'scorm_');
+        if ($tmpPath === false) {
+            throw new Exception('ScormDisk — could not create OS temp file.');
+        }
+
+        $tmpHandle = fopen($tmpPath, 'wb');
+        if ($tmpHandle === false) {
+            unlink($tmpPath);
+            throw new Exception('ScormDisk — could not open OS temp file for writing: ' . $tmpPath);
+        }
+
+        try {
+            stream_copy_to_stream($stream, $tmpHandle);
+        } finally {
+            fclose($tmpHandle);
+            // The caller-supplied S3 stream is no longer needed.
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+
+        return $tmpPath;
+    }
+
+    /**
+     * Delete the SCORM content directory from the scorm S3 bucket.
+     */
+    private function deleteScormContent(string $folderHashedName): bool
     {
         try {
-            return $this->getDisk()->deleteDirectory($folderHashedName);
+            return (bool) $this->getDisk()->deleteDirectory($folderHashedName);
         } catch (Exception $ex) {
-            Log::error($ex->getMessage());
+            Log::error('ScormDisk::deleteScormContent — ' . $ex->getMessage());
+            return false;
         }
     }
 
     /**
-     * @param string $directory
-     * @return bool
+     * Delete the SCORM archive directory from the archive S3 bucket.
      */
-    private function deleteScormArchive($uuid)
+    private function deleteScormArchive(string $uuid): bool
     {
         try {
-            return $this->getArchiveDisk()->deleteDirectory($uuid);
+            return (bool) $this->getArchiveDisk()->deleteDirectory($uuid);
         } catch (Exception $ex) {
-            Log::error($ex->getMessage());
+            Log::error('ScormDisk::deleteScormArchive — ' . $ex->getMessage());
+            return false;
         }
     }
 
     /**
-     * 
-     * @param array $paths
-     * @return string joined path
+     * Join path segments using '/' — always correct for S3 keys regardless
+     * of the host OS's DIRECTORY_SEPARATOR.
      */
-    private function join(...$paths)
+    private function joinS3(string ...$paths): string
     {
-        return  implode(DIRECTORY_SEPARATOR, $paths);
-    }
-
-    private function isDirectory($zipEntryName)
-    {
-        return substr($zipEntryName, -1) ===  '/';
-    }
-
-    private function cleanPath($path)
-    {
-        return str_replace('/', DIRECTORY_SEPARATOR, $path);
+        return implode('/', array_filter($paths, fn($p) => $p !== ''));
     }
 
     /**
-     * @return FilesystemAdapter $disk
+     * Normalise a path to use '/' (S3 convention).
+     * Strips a trailing slash so the result is always a key prefix, not
+     * a directory placeholder.
      */
-    private function getDisk()
+    private function normalizeS3Key(string $path): string
+    {
+        // Convert OS separators → S3 separator, then strip trailing slash.
+        return rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $path), '/');
+    }
+
+    /**
+     * Returns true when the zip entry represents a directory.
+     */
+    private function isDirectory(string $zipEntryName): bool
+    {
+        return str_ends_with($zipEntryName, '/');
+    }
+
+    /**
+     * Resolve and validate the scorm content disk.
+     *
+     * @return FilesystemAdapter
+     * @throws StorageNotFoundException
+     */
+    private function getDisk(): FilesystemAdapter
     {
         $diskName = config('scorm.disk');
         if (empty($diskName)) {
             throw new StorageNotFoundException('scorm_disk_not_configured');
         }
-
         if (!config()->has('filesystems.disks.' . $diskName)) {
-            throw new StorageNotFoundException('scorm_disk_not_define: ' . $diskName);
+            throw new StorageNotFoundException('scorm_disk_not_defined: ' . $diskName);
         }
-
-        $disk = Storage::disk($diskName);
-
-        return $disk;
+        return Storage::disk($diskName);
     }
 
     /**
-     * @return FilesystemAdapter $disk
+     * Resolve and validate the scorm archive disk.
+     *
+     * @return FilesystemAdapter
+     * @throws StorageNotFoundException
      */
-    private function getArchiveDisk()
+    private function getArchiveDisk(): FilesystemAdapter
     {
         $archiveDiskName = config('scorm.archive');
         if (empty($archiveDiskName)) {
             throw new StorageNotFoundException('scorm_archive_disk_not_configured');
         }
-
         if (!config()->has('filesystems.disks.' . $archiveDiskName)) {
-            throw new StorageNotFoundException('scorm_archive_disk_not_define: ' . $archiveDiskName);
+            throw new StorageNotFoundException('scorm_archive_disk_not_defined: ' . $archiveDiskName);
         }
-
-        $disk = Storage::disk($archiveDiskName);
-
-        return $disk;
+        return Storage::disk($archiveDiskName);
     }
 }

--- a/src/Manager/ScormDisk.php
+++ b/src/Manager/ScormDisk.php
@@ -94,7 +94,7 @@ class ScormDisk
         }
 
         $entryUrl = $scos[0]->entryUrl ?? $scos[0]->scoChildren[0]->entryUrl ?? '';
-        $entryUrl = $this->prefixEntryUrl($entryUrl, $manifestPath);
+        // $entryUrl = $this->prefixEntryUrl($entryUrl, $manifestPath);
 
         return [
             'identifier' => $manifest->attributes->getNamedItem('identifier')->nodeValue,

--- a/src/Manager/ScormDisk.php
+++ b/src/Manager/ScormDisk.php
@@ -29,23 +29,20 @@ class ScormDisk
      */
     public function contentExists(string $uuid): bool
     {
-        $disk   = $this->getScormDisk();
-        $prefix = $this->normalizeKey($uuid);
-
-        // Fast path — manifest at the expected root location
-        if ($disk->exists($prefix . '/imsmanifest.xml')) {
-            return true;
-        }
-
-        // Slower path — manifest may be nested in a subdirectory
         try {
+            $disk   = $this->getScormDisk();
+            $prefix = $this->normalizeKey($uuid);
+
+            if ($disk->exists($prefix . '/imsmanifest.xml')) {
+                return true;
+            }
+
             foreach ($disk->allFiles($prefix) as $path) {
                 if (str_ends_with($path, 'imsmanifest.xml')) {
                     return true;
                 }
             }
         } catch (\Throwable $e) {
-            // S3 throws when the prefix doesn't exist at all
             return false;
         }
 
@@ -159,15 +156,19 @@ class ScormDisk
 
     private function findManifest(FilesystemAdapter $disk, string $prefix): ?string
     {
-        $direct = $prefix . '/imsmanifest.xml';
-        if ($disk->exists($direct)) {
-            return $direct;
-        }
-
-        foreach ($disk->allFiles($prefix) as $path) {
-            if (str_ends_with($path, 'imsmanifest.xml')) {
-                return $path;
+        try {
+            $direct = $prefix . '/imsmanifest.xml';
+            if ($disk->exists($direct)) {
+                return $direct;
             }
+
+            foreach ($disk->allFiles($prefix) as $path) {
+                if (str_ends_with($path, 'imsmanifest.xml')) {
+                    return $path;
+                }
+            }
+        } catch (\Throwable $e) {
+            return null;
         }
 
         return null;

--- a/src/Manager/ScormDisk.php
+++ b/src/Manager/ScormDisk.php
@@ -18,11 +18,9 @@ class ScormDisk
 {
     private ScormLib $scormLib;
 
-    public function __construct(
-        private readonly UnzipperInterface $unzipper,
-        ?ScormLib $scormLib = null,
-    ) {
-        $this->scormLib = $scormLib ?? new ScormLib();
+    public function __construct(private readonly UnzipperInterface $unzipper)
+    {
+        $this->scormLib = new ScormLib();
     }
 
     /**
@@ -34,14 +32,21 @@ class ScormDisk
         $disk   = $this->getScormDisk();
         $prefix = $this->normalizeKey($uuid);
 
+        // Fast path — manifest at the expected root location
         if ($disk->exists($prefix . '/imsmanifest.xml')) {
             return true;
         }
 
-        foreach ($disk->allFiles($prefix) as $path) {
-            if (str_ends_with($path, 'imsmanifest.xml')) {
-                return true;
+        // Slower path — manifest may be nested in a subdirectory
+        try {
+            foreach ($disk->allFiles($prefix) as $path) {
+                if (str_ends_with($path, 'imsmanifest.xml')) {
+                    return true;
+                }
             }
+        } catch (\Throwable $e) {
+            // S3 throws when the prefix doesn't exist at all
+            return false;
         }
 
         return false;

--- a/src/Manager/ScormDisk.php
+++ b/src/Manager/ScormDisk.php
@@ -68,10 +68,12 @@ class ScormDisk
                     continue;
                 }
 
-                // writeStream() hands the resource straight to the S3 SDK —
-                // no intermediate local write.
+                // writeStream() passes the resource to the S3 SDK which may
+                // close it internally before returning. Guard before fclose.
                 $disk->writeStream($destination, $stream);
-                fclose($stream);
+                if (is_resource($stream)) {
+                    fclose($stream);
+                }
             }
         } finally {
             $zip->close();
@@ -171,7 +173,9 @@ class ScormDisk
             stream_copy_to_stream($stream, $tmpHandle);
         } finally {
             fclose($tmpHandle);
-            // The caller-supplied S3 stream is no longer needed.
+            // The S3 SDK / Flysystem may close the stream internally during
+            // stream_copy_to_stream. Guard with is_resource before fclose to
+            // avoid "supplied resource is not a valid stream resource" errors.
             if (is_resource($stream)) {
                 fclose($stream);
             }

--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -224,16 +224,31 @@ class ScormManager
         if (!empty($scormData['scos']) && is_array($scormData['scos'])) {
             /** @var Sco $scoData */
             foreach ($scormData['scos'] as $scoData) {
-                $sco = $this->saveScormScos($scorm->id, $scoData);
-                if ($scoData->scoChildren) {
-                    foreach ($scoData->scoChildren as $scoChild) {
-                        $this->saveScormScos($scorm->id, $scoChild, $sco->id);
-                    }
-                }
+                $this->saveScormScosRecursively($scorm->id, $scoData);
             }
         }
 
         return  $scorm;
+    }
+
+    /**
+     * Save Scorm sco and it's nested children recursively
+     * @param int $scorm_id scorm id.
+     * @param Sco $scoData Sco data to be store.
+     * @param int $sco_parent_id sco parent id for children
+     */
+    private function saveScormScosRecursively($scorm_id, $scoData, $sco_parent_id = null)
+    {
+        $sco = $this->saveScormScos($scorm_id, $scoData, $sco_parent_id);
+        
+        // Recursively save children
+        if ($scoData->scoChildren && is_array($scoData->scoChildren)) {
+            foreach ($scoData->scoChildren as $scoChild) {
+                $this->saveScormScosRecursively($scorm_id, $scoChild, $sco->id);
+            }
+        }
+        
+        return $sco;
     }
 
     /**

--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -222,15 +222,13 @@ class ScormManager
         $scorm->save();
 
         if (!empty($scormData['scos']) && is_array($scormData['scos'])) {
-            \Log::info('saveScorm: Starting to save ' . count($scormData['scos']) . ' SCOs');
+            \Log::info('saveScorm: Saving ' . count($scormData['scos']) . ' SCOs');
             /** @var Sco $scoData */
-            foreach ($scormData['scos'] as $index => $scoData) {
-                \Log::info("saveScorm: Saving SCO #{$index} with identifier: " . $scoData->getIdentifier());
+            foreach ($scormData['scos'] as $scoData) {
                 $this->saveScormScosRecursively($scorm->id, $scoData);
             }
-            \Log::info('saveScorm: Finished saving all SCOs');
         } else {
-            \Log::warning('saveScorm: No SCOs to save or scos is not an array');
+            \Log::warning('saveScorm: No SCOs to save');
         }
 
         return  $scorm;
@@ -244,21 +242,13 @@ class ScormManager
      */
     private function saveScormScosRecursively($scorm_id, $scoData, $sco_parent_id = null)
     {
-        \Log::info("saveScormScosRecursively: Saving SCO with identifier: " . $scoData->getIdentifier() . ", parent_id: " . ($sco_parent_id ?: 'null'));
-        
         $sco = $this->saveScormScos($scorm_id, $scoData, $sco_parent_id);
-        
-        \Log::info("saveScormScosRecursively: Successfully saved SCO with ID: " . $sco->id . ", UUID: " . $sco->uuid);
         
         // Recursively save children
         if ($scoData->scoChildren && is_array($scoData->scoChildren)) {
-            \Log::info("saveScormScosRecursively: SCO has " . count($scoData->scoChildren) . " children, saving recursively...");
-            foreach ($scoData->scoChildren as $index => $scoChild) {
-                \Log::info("saveScormScosRecursively: Saving child #{$index} with identifier: " . $scoChild->getIdentifier());
+            foreach ($scoData->scoChildren as $scoChild) {
                 $this->saveScormScosRecursively($scorm_id, $scoChild, $sco->id);
             }
-        } else {
-            \Log::info("saveScormScosRecursively: SCO has no children");
         }
         
         return $sco;
@@ -272,8 +262,6 @@ class ScormManager
      */
     private function saveScormScos($scorm_id, $scoData, $sco_parent_id = null)
     {
-        \Log::info("saveScormScos: Creating SCO model for identifier: " . $scoData->getIdentifier());
-        
         $sco    =   new ScormScoModel();
         $sco->scorm_id  =   $scorm_id;
         $sco->uuid  =   $scoData->uuid;
@@ -292,11 +280,9 @@ class ScormManager
         $sco->completion_threshold  =   $scoData->completionThreshold;
         $sco->prerequisites  =   $scoData->prerequisites;
         
-        \Log::info("saveScormScos: SCO data prepared - UUID: " . $sco->uuid . ", identifier: " . $sco->identifier . ", title: " . $sco->title . ", entry_url: " . $sco->entry_url);
-        
         $sco->save();
         
-        \Log::info("saveScormScos: SCO saved successfully with ID: " . $sco->id);
+        \Log::info("saveScormScos: Saved SCO - " . $sco->identifier);
         return $sco;
     }
 
@@ -369,28 +355,17 @@ class ScormManager
         } else {
             $this->onError('invalid_scorm_version_message');
         }
-        \Log::info('parseScormArchive: Calling parseOrganizationsNode');
         $scos = $this->scormLib->parseOrganizationsNode($dom);
-
-        \Log::info('parseScormArchive: parseOrganizationsNode returned ' . count($scos) . ' SCOs');
 
         if (0 >= count($scos)) {
             \Log::error('parseScormArchive: No SCOs found in SCORM archive');
             $this->onError('no_sco_in_scorm_archive_message');
         }
 
-        // Log details about each SCO
-        foreach ($scos as $index => $sco) {
-            \Log::info("parseScormArchive: SCO #{$index} - identifier: " . $sco->getIdentifier() . ", title: " . $sco->getTitle() . ", entryUrl: " . $sco->getEntryUrl() . ", isBlock: " . ($sco->isBlock() ? 'true' : 'false'));
-            if ($sco->getScoChildren() && is_array($sco->getScoChildren())) {
-                \Log::info("parseScormArchive: SCO #{$index} has " . count($sco->getScoChildren()) . " children");
-            }
-        }
-
         $data['entryUrl'] = $scos[0]->entryUrl ?? $scos[0]->scoChildren[0]->entryUrl;
         $data['scos'] = $scos;
         
-        \Log::info('parseScormArchive: Final entryUrl: ' . $data['entryUrl']);
+        \Log::info('parseScormArchive: Found ' . count($scos) . ' SCOs, entryUrl: ' . $data['entryUrl']);
         
         // Include manifest path for later use in entry URL adjustment
         $data['manifestPath'] = $manifestResult['path'];

--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -87,6 +87,7 @@ class ScormManager
 
         $zip->close();
         if (!$isScormArchive) {
+            \Log::error('Zip open errorCode: ' . $openValue);
             $this->onError('invalid_scorm_archive_message');
         }
     }

--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -1,1070 +1,550 @@
 <?php
 
-
 namespace Peopleaps\Scorm\Manager;
 
 use Carbon\Carbon;
-use DOMDocument;
+use DateInterval;
+use DateTime;
+use Exception;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Peopleaps\Scorm\Contract\UnzipperInterface;
 use Peopleaps\Scorm\Entity\Scorm;
+use Peopleaps\Scorm\Entity\Sco;
 use Peopleaps\Scorm\Entity\ScoTracking;
 use Peopleaps\Scorm\Exception\InvalidScormArchiveException;
-use Peopleaps\Scorm\Library\ScormLib;
 use Peopleaps\Scorm\Model\ScormModel;
 use Peopleaps\Scorm\Model\ScormScoModel;
 use Peopleaps\Scorm\Model\ScormScoTrackingModel;
-use Illuminate\Support\Str;
-use Peopleaps\Scorm\Entity\Sco;
 
 class ScormManager
 {
-    /** @var ScormLib */
-    private $scormLib;
-    /** @var ScormDisk */
-    private $scormDisk;
-    /** @var string $uuid */
-    private $uuid;
+    private readonly ScormDisk $scormDisk;
+
+    public function __construct(?UnzipperInterface $unzipper = null)
+    {
+        $this->scormDisk = new ScormDisk(
+            $unzipper ?? new LocalUnzipper(
+                Storage::disk(config('scorm.archive')),
+                Storage::disk(config('scorm.disk')),
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Upload / ingest
+    // -------------------------------------------------------------------------
 
     /**
-     * Constructor.
+     * Ingest a SCORM package already present on the archive disk (e.g. uploaded
+     * directly to S3). Pass the object key as $archiveKey.
      *
-     * @param string $filesDir
-     * @param string $uploadDir
-     */
-    public function __construct()
-    {
-        $this->scormLib = new ScormLib();
-        $this->scormDisk = new ScormDisk();
-    }
-
-    public function uploadScormFromUri($file, $uuid = null)
-    {
-        // $uuid is meant for user to update scorm content. Hence, if user want to update content should parse in existing uuid
-        $this->uuid =  $uuid ?? Str::uuid()->toString();
-
-        // Validate that the file parameter is not empty
-        if (empty($file)) {
-            throw new InvalidScormArchiveException('file_parameter_empty');
-        }
-
-        // Log the file being processed for debugging
-        \Log::info('Uploading SCORM from URI: ' . $file);
-
-        $scorm = null;
-        $this->scormDisk->readScormArchive($file, function ($path) use (&$scorm, $file, $uuid) {
-            $filename = basename($file);
-            $scorm = $this->saveScorm($path, $filename, $uuid);
-        });
-        return $scorm;
-    }
-
-    /**
-     * @param UploadedFile $file
-     * @param null|string $uuid
-     * @return ScormModel
      * @throws InvalidScormArchiveException
      */
-    public function uploadScormArchive(UploadedFile $file, $uuid = null)
+    public function uploadScormFromUri(string $archiveKey, ?string $uuid = null): ScormModel
     {
-        // $uuid is meant for user to update scorm content. Hence, if user want to update content should parse in existing uuid
-        $this->uuid =  $uuid ?? Str::uuid()->toString();
+        $uuid = $uuid ?? Str::uuid()->toString();
 
-        return $this->saveScorm($file, $file->getClientOriginalName(), $uuid);
+        if (!$this->scormDisk->contentExists($uuid)) {
+            $this->scormDisk->extractFromArchive($archiveKey, $uuid);
+        }
+
+        return $this->persistScorm(
+            uuid: $uuid,
+            filename: basename($archiveKey),
+            packageSize: 0,
+        );
     }
 
     /**
-     * Find imsmanifest.xml location in ZIP archive
-     * 
-     * @param \ZipArchive $zip
-     * @return array ['found' => bool, 'path' => string, 'stream' => resource|null]
-     */
-    private function findManifestInZip(\ZipArchive $zip)
-    {
-        // Look for imsmanifest.xml in root directory first
-        $manifestStream = $zip->getStream('imsmanifest.xml');
-
-        if ($manifestStream) {
-            \Log::info('Found imsmanifest.xml in root directory');
-            return [
-                'found' => true,
-                'path' => 'imsmanifest.xml',
-                'stream' => $manifestStream
-            ];
-        }
-
-        // Search for imsmanifest.xml in subdirectories
-        \Log::info('imsmanifest.xml not found in root, searching subdirectories...');
-
-        for ($i = 0; $i < $zip->numFiles; $i++) {
-            $filename = $zip->getNameIndex($i);
-
-            // Check if this file is imsmanifest.xml (case insensitive)
-            if (strtolower(basename($filename)) === 'imsmanifest.xml') {
-                $manifestStream = $zip->getStream($filename);
-                if ($manifestStream) {
-                    \Log::info('Found imsmanifest.xml at: ' . $filename);
-                    return [
-                        'found' => true,
-                        'path' => $filename,
-                        'stream' => $manifestStream
-                    ];
-                }
-            }
-        }
-
-        return [
-            'found' => false,
-            'path' => '',
-            'stream' => null
-        ];
-    }
-
-    /**
-     *  Checks if it is a valid scorm archive
-     * 
-     * @param string|UploadedFile $file zip.       
-     */
-    private function validatePackage($file)
-    {
-        $zip = new \ZipArchive();
-        $manifestResult = null;
-
-        try {
-            $openValue = $zip->open($file);
-
-            if ($openValue !== true) {
-                \Log::error('Zip open errorCode: ' . $openValue);
-                $this->onError('invalid_scorm_archive_message');
-            }
-
-            $manifestResult = $this->findManifestInZip($zip);
-        } finally {
-            // Always close resources
-            if ($manifestResult && $manifestResult['stream'] && is_resource($manifestResult['stream'])) {
-                fclose($manifestResult['stream']);
-            }
-            $zip->close();
-        }
-
-        if (!$manifestResult['found']) {
-            \Log::error('imsmanifest.xml not found anywhere in the ZIP archive');
-            $this->onError('invalid_scorm_archive_message');
-        }
-
-        \Log::info('SCORM archive validation successful. Manifest found at: ' . $manifestResult['path']);
-    }
-
-    /**
-     *  Save scorm data
+     * Accept a freshly-uploaded zip file, store it on the archive disk, extract
+     * it and persist the resulting SCORM record.
      *
-     * @param string|UploadedFile $file zip.
-     * @param string $filename
-     * @param null|string $uuid
-     * @return ScormModel
      * @throws InvalidScormArchiveException
      */
-    private function saveScorm($file, $filename, $uuid = null)
+    public function uploadScormArchive(UploadedFile $file, ?string $uuid = null): ScormModel
     {
-        $this->validatePackage($file);
-        $scormData  =   $this->generateScorm($file);
-        // save to db
-        if (is_null($scormData) || !is_array($scormData)) {
-            $this->onError('invalid_scorm_data');
-        }
+        $uuid       = $uuid ?? Str::uuid()->toString();
+        $archiveKey = $uuid . '/' . $file->getClientOriginalName();
 
-        // This uuid is use when the admin wants to edit existing scorm file.
-        if (!empty($uuid)) {
-            $this->uuid =   $uuid; // Overwrite system generated uuid
-        }
+        $this->scormDisk->putArchiveFile($file, $archiveKey);
+        $this->scormDisk->extractFromArchive($archiveKey, $uuid);
 
-        /**
-         * ScormModel::whereUuid Query Builder style equals ScormModel::where('uuid',$value)
-         * 
-         * From Laravel doc https://laravel.com/docs/5.0/queries#advanced-wheres.
-         * Dynamic Where Clauses
-         * You may even use "dynamic" where statements to fluently build where statements using magic methods:
-         * 
-         * Examples: 
-         * 
-         * $admin = DB::table('users')->whereId(1)->first();
-         * From laravel framework https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Query/Builder.php'
-         *  Handle dynamic method calls into the method.
-         *  return $this->dynamicWhere($method, $parameters);
-         **/
-        // $scorm = ScormModel::whereOriginFile($filename);
-        // Uuid indicator is better than filename for update content or add new content.
-        $scorm = ScormModel::where('uuid', $this->uuid);
-
-        // Check if scom package already exists to drop old one.
-        if (!$scorm->exists()) {
-            $scorm = new ScormModel();
-        } else {
-            $scorm = $scorm->first();
-            $this->deleteScormData($scorm);
-        }
-
-        $scorm->uuid =   $this->uuid;
-        $scorm->title =   $scormData['title'];
-        $scorm->version =   $scormData['version'];
-        $scorm->entry_url =   $scormData['entryUrl'];
-        $scorm->identifier =   $scormData['identifier'];
-        $scorm->origin_file =   $filename;
-
-        // Auto-detect and set metadata
-        $scorm->metadata = [
-            'package_size' => $this->getFileSize($file),
-            'created_at' => $scormData['created_at'] ?? null,
-            'created_by' => $scormData['created_by'] ?? null
-        ];
-
-        $scorm->save();
-
-        if (!empty($scormData['scos']) && is_array($scormData['scos'])) {
-            \Log::info('saveScorm: Saving ' . count($scormData['scos']) . ' SCOs');
-            /** @var Sco $scoData */
-            foreach ($scormData['scos'] as $scoData) {
-                $this->saveScormScosRecursively($scorm->id, $scoData);
-            }
-        } else {
-            \Log::warning('saveScorm: No SCOs to save');
-        }
-
-        return  $scorm;
+        return $this->persistScorm(
+            uuid: $uuid,
+            filename: $file->getClientOriginalName(),
+            packageSize: $file->getSize(),
+        );
     }
 
-    /**
-     * Save Scorm sco and it's nested children recursively
-     * @param int $scorm_id scorm id.
-     * @param Sco $scoData Sco data to be store.
-     * @param int $sco_parent_id sco parent id for children
-     */
-    private function saveScormScosRecursively($scorm_id, $scoData, $sco_parent_id = null)
+    // -------------------------------------------------------------------------
+    // Delete
+    // -------------------------------------------------------------------------
+
+    public function deleteScorm(ScormModel $model): void
     {
-        $sco = $this->saveScormScos($scorm_id, $scoData, $sco_parent_id);
-
-        // Recursively save children
-        if ($scoData->scoChildren && is_array($scoData->scoChildren)) {
-            foreach ($scoData->scoChildren as $scoChild) {
-                $this->saveScormScosRecursively($scorm_id, $scoChild, $sco->id);
-            }
-        }
-
-        return $sco;
+        $this->deleteScormData($model);
+        $model->delete();
     }
 
-    /**
-     * Save Scorm sco and it's nested children
-     * @param int $scorm_id scorm id.
-     * @param Sco $scoData Sco data to be store.
-     * @param int $sco_parent_id sco parent id for children
-     */
-    private function saveScormScos($scorm_id, $scoData, $sco_parent_id = null)
+    // -------------------------------------------------------------------------
+    // Query helpers
+    // -------------------------------------------------------------------------
+
+    public function getScos(int $scormId)
     {
-        $sco    =   new ScormScoModel();
-        $sco->scorm_id  =   $scorm_id;
-        $sco->uuid  =   $scoData->uuid;
-        $sco->sco_parent_id  =   $sco_parent_id;
-        $sco->entry_url  =   $scoData->entryUrl;
-        $sco->identifier  =   $scoData->identifier;
-        $sco->title  =   $scoData->title;
-        $sco->visible  =   $scoData->visible;
-        $sco->sco_parameters  =   $scoData->parameters;
-        $sco->launch_data  =   $scoData->launchData;
-        $sco->max_time_allowed  =   $scoData->maxTimeAllowed;
-        $sco->time_limit_action  =   $scoData->timeLimitAction;
-        $sco->block  =   $scoData->block;
-        $sco->score_int  =   $scoData->scoreToPassInt;
-        $sco->score_decimal  =   $scoData->scoreToPassDecimal;
-        $sco->completion_threshold  =   $scoData->completionThreshold;
-        $sco->prerequisites  =   $scoData->prerequisites;
-
-        $sco->save();
-
-        \Log::info("saveScormScos: Saved SCO - " . $sco->identifier);
-        return $sco;
+        return ScormScoModel::with('scorm')->where('scorm_id', $scormId)->get();
     }
 
-    /**
-     * @param string|UploadedFile $file zip.       
-     */
-    private function parseScormArchive($file)
+    public function getScoByUuid(string $scoUuid): ScormScoModel
     {
-        $data = [];
-        $contents = '';
-        $zip = new \ZipArchive();
-        $manifestResult = null;
-
-        try {
-            $openValue = $zip->open($file);
-
-            if ($openValue !== true) {
-                \Log::error('Failed to open ZIP file in parseScormArchive. Error code: ' . $openValue);
-                $this->onError('cannot_load_imsmanifest_message');
-            }
-
-            $manifestResult = $this->findManifestInZip($zip);
-
-            if (!$manifestResult['found']) {
-                $this->onError('cannot_load_imsmanifest_message');
-            }
-
-            while (!feof($manifestResult['stream'])) {
-                $contents .= fread($manifestResult['stream'], 2);
-            }
-        } finally {
-            // Always close resources
-            if ($manifestResult && $manifestResult['stream'] && is_resource($manifestResult['stream'])) {
-                fclose($manifestResult['stream']);
-            }
-            $zip->close();
-        }
-
-        $dom = new DOMDocument();
-
-        // Fix XML entity errors by escaping unescaped ampersands
-        $contents = $this->fixXmlEntities($contents);
-
-        if (!$dom->loadXML($contents)) {
-            $this->onError('cannot_load_imsmanifest_message');
-        }
-
-        $manifest = $dom->getElementsByTagName('manifest')->item(0);
-        if (!is_null($manifest->attributes->getNamedItem('identifier'))) {
-            $data['identifier'] = $manifest->attributes->getNamedItem('identifier')->nodeValue;
-        } else {
-            $this->onError('invalid_scorm_manifest_identifier');
-        }
-        $titles = $dom->getElementsByTagName('title');
-        if ($titles->length > 0) {
-            $data['title'] = Str::of($titles->item(0)->textContent)->trim('/n')->trim();
-        }
-
-        $scormVersionElements = $dom->getElementsByTagName('schemaversion');
-        if ($scormVersionElements->length > 0) {
-            switch ($scormVersionElements->item(0)->textContent) {
-                case '1.2':
-                    $data['version'] = Scorm::SCORM_12;
-                    break;
-                case 'CAM 1.3':
-                case '2004 3rd Edition':
-                case '2004 4th Edition':
-                    $data['version'] = Scorm::SCORM_2004;
-                    break;
-                default:
-                    $this->onError('invalid_scorm_version_message');
-            }
-        } else {
-            $this->onError('invalid_scorm_version_message');
-        }
-        $scos = $this->scormLib->parseOrganizationsNode($dom);
-
-        if (0 >= count($scos)) {
-            \Log::error('parseScormArchive: No SCOs found in SCORM archive');
-            $this->onError('no_sco_in_scorm_archive_message');
-        }
-
-        $data['entryUrl'] = $scos[0]->entryUrl ?? $scos[0]->scoChildren[0]->entryUrl;
-        $data['scos'] = $scos;
-
-        \Log::info('parseScormArchive: Found ' . count($scos) . ' SCOs, entryUrl: ' . $data['entryUrl']);
-
-        // Include manifest path for later use in entry URL adjustment
-        $data['manifestPath'] = $manifestResult['path'];
-
-        // Extract creation date and creator from manifest metadata
-        $data['created_at'] = $this->extractCreationDate($dom);
-        $data['created_by'] = $this->extractCreator($dom);
-
-        return $data;
+        return ScormScoModel::with('scorm')->where('uuid', $scoUuid)->firstOrFail();
     }
 
-    public function deleteScorm($model)
-    {
-        // Delete after the previous item is stored
-        if ($model) {
-            $this->deleteScormData($model);
-            $model->delete(); // delete scorm
-        }
-    }
-
-    private function deleteScormData($model)
-    {
-        // Delete after the previous item is stored
-        $oldScos = $model->scos()->get();
-
-        // Delete all tracking associate with sco
-        foreach ($oldScos as $oldSco) {
-            $oldSco->scoTrackings()->delete();
-        }
-        $model->scos()->delete(); // delete scos
-        // Delete folder from server
-        $this->deleteScormFolder($model->uuid);
-    }
-
-    /**
-     * @param $folderHashedName
-     * @return bool
-     */
-    protected function deleteScormFolder($folderHashedName)
-    {
-        return $this->scormDisk->deleteScorm($folderHashedName);
-    }
-
-    /**
-     * @param string|UploadedFile $file zip.       
-     * @return array
-     * @throws InvalidScormArchiveException
-     */
-    private function generateScorm($file)
-    {
-        $scormData = $this->parseScormArchive($file);
-        /**
-         * Unzip a given ZIP file into the web resources directory.
-         *
-         * @param string $hashName name of the destination directory
-         */
-        $this->scormDisk->unzipper($file, $this->uuid);
-
-        // Update main entry URL to include root path if content is in subdirectory
-        // Use the manifest path we already calculated during parsing
-        if (isset($scormData['manifestPath']) && strpos($scormData['manifestPath'], '/') !== false) {
-            $parentPath = dirname($scormData['manifestPath']);
-            $originalEntryUrl = $scormData['entryUrl'];
-            $scormData['entryUrl'] = $parentPath . '/' . ltrim($scormData['entryUrl'], '/');
-            \Log::info("SCORM content in subdirectory '{$parentPath}'. Entry URL: {$originalEntryUrl} -> {$scormData['entryUrl']}");
-        } else {
-            \Log::info("SCORM content in root directory. Entry URL unchanged: {$scormData['entryUrl']}");
-        }
-
-        return [
-            'identifier' => $scormData['identifier'],
-            'uuid' => $this->uuid,
-            'title' => $scormData['title'], // to follow standard file data format
-            'version' => $scormData['version'],
-            'entryUrl' => $scormData['entryUrl'],
-            'scos' => $scormData['scos'],
-        ];
-    }
-
-    /**
-     * Get SCO list
-     * @param $scormId
-     * @return \Illuminate\Database\Eloquent\Builder[]|\Illuminate\Database\Eloquent\Collection
-     */
-    public function getScos($scormId)
-    {
-        $scos  =   ScormScoModel::with([
-            'scorm'
-        ])->where('scorm_id', $scormId)
-            ->get();
-
-        return $scos;
-    }
-
-    /**
-     * Get sco by uuid
-     * @param $scoUuid
-     * @return null|\Illuminate\Database\Eloquent\Builder|Model
-     */
-    public function getScoByUuid($scoUuid)
-    {
-        $sco    =   ScormScoModel::with(['scorm'])
-            ->where('uuid', $scoUuid)
-            ->firstOrFail();
-
-        return $sco;
-    }
-
-    public function getUserResult($scoId, $userId)
+    public function getUserResult(int $scoId, int $userId): ?ScormScoTrackingModel
     {
         return ScormScoTrackingModel::where('sco_id', $scoId)->where('user_id', $userId)->first();
     }
 
-    public function createScoTracking($scoUuid, $userId = null, $userName = null)
-    {
-        $sco    =   ScormScoModel::where('uuid', $scoUuid)->firstOrFail();
+    // -------------------------------------------------------------------------
+    // Tracking
+    // -------------------------------------------------------------------------
 
+    public function createScoTracking(string $scoUuid, mixed $userId = null, ?string $userName = null): ScoTracking
+    {
+        $sco     = ScormScoModel::where('uuid', $scoUuid)->firstOrFail();
         $version = $sco->scorm->version;
-        $scoTracking = new ScoTracking();
-        $scoTracking->setSco($sco->toArray());
 
-        $cmi = null;
-        switch ($version) {
-            case Scorm::SCORM_12:
-                $scoTracking->setLessonStatus('not attempted');
-                $scoTracking->setSuspendData('');
-                $scoTracking->setEntry('ab-initio');
-                $scoTracking->setLessonLocation('');
-                $scoTracking->setCredit('no-credit');
-                $scoTracking->setTotalTimeInt(0);
-                $scoTracking->setSessionTime(0);
-                $scoTracking->setLessonMode('normal');
-                $scoTracking->setExitMode('');
+        $tracking = new ScoTracking();
+        $tracking->setSco($sco->toArray());
 
-                if (is_null($sco->prerequisites)) {
-                    $scoTracking->setIsLocked(false);
-                } else {
-                    $scoTracking->setIsLocked(true);
-                }
-                $cmi = [
-                    'cmi.core.entry' => $scoTracking->getEntry(),
-                    'cmi.core.student_id' => $userId,
-                    'cmi.core.student_name' => $userName,
-                ];
+        $cmi = match ($version) {
+            Scorm::SCORM_12 => $this->initScorm12Tracking($tracking, $sco, $userId, $userName),
+            Scorm::SCORM_2004 => $this->initScorm2004Tracking($tracking, $userId, $userName),
+            default => [],
+        };
 
-                break;
-            case Scorm::SCORM_2004:
-                $scoTracking->setTotalTimeString('PT0S');
-                $scoTracking->setCompletionStatus('unknown');
-                $scoTracking->setLessonStatus('unknown');
-                $scoTracking->setIsLocked(false);
-                $cmi = [
-                    'cmi.entry' => 'ab-initio',
-                    'cmi.learner_id' =>  $userId,
-                    'cmi.learner_name' => $userName,
-                    'cmi.scaled_passing_score' => 0.5,
-                ];
-                break;
-        }
+        $tracking->setUserId($userId);
+        $tracking->setDetails($cmi);
 
-        $scoTracking->setUserId($userId);
-        $scoTracking->setDetails($cmi);
+        $stored = ScormScoTrackingModel::firstOrCreate(
+            ['user_id' => $userId, 'sco_id' => $sco->id],
+            [
+                'uuid'               => Str::uuid()->toString(),
+                'progression'        => $tracking->getProgression(),
+                'score_raw'          => $tracking->getScoreRaw(),
+                'score_min'          => $tracking->getScoreMin(),
+                'score_max'          => $tracking->getScoreMax(),
+                'score_scaled'       => $tracking->getScoreScaled(),
+                'lesson_status'      => $tracking->getLessonStatus(),
+                'completion_status'  => $tracking->getCompletionStatus(),
+                'session_time'       => $tracking->getSessionTime(),
+                'total_time_int'     => $tracking->getTotalTimeInt(),
+                'total_time_string'  => $tracking->getTotalTimeString(),
+                'entry'              => $tracking->getEntry(),
+                'suspend_data'       => $tracking->getSuspendData(),
+                'credit'             => $tracking->getCredit(),
+                'exit_mode'          => $tracking->getExitMode(),
+                'lesson_location'    => $tracking->getLessonLocation(),
+                'lesson_mode'        => $tracking->getLessonMode(),
+                'is_locked'          => $tracking->getIsLocked(),
+                'details'            => $tracking->getDetails(),
+                'latest_date'        => $tracking->getLatestDate(),
+                'created_at'         => Carbon::now(),
+                'updated_at'         => Carbon::now(),
+            ],
+        );
 
-        // Create a new tracking model
-        $storeTracking  =   ScormScoTrackingModel::firstOrCreate([
-            'user_id'   =>  $userId,
-            'sco_id'    =>  $sco->id
-        ], [
-            'uuid'  =>   Str::uuid()->toString(),
-            'progression'  =>  $scoTracking->getProgression(),
-            'score_raw'  =>  $scoTracking->getScoreRaw(),
-            'score_min'  =>  $scoTracking->getScoreMin(),
-            'score_max'  =>  $scoTracking->getScoreMax(),
-            'score_scaled'  =>  $scoTracking->getScoreScaled(),
-            'lesson_status'  =>  $scoTracking->getLessonStatus(),
-            'completion_status'  =>  $scoTracking->getCompletionStatus(),
-            'session_time'  =>  $scoTracking->getSessionTime(),
-            'total_time_int'  =>  $scoTracking->getTotalTimeInt(),
-            'total_time_string'  =>  $scoTracking->getTotalTimeString(),
-            'entry'  =>  $scoTracking->getEntry(),
-            'suspend_data'  =>  $scoTracking->getSuspendData(),
-            'credit'  =>  $scoTracking->getCredit(),
-            'exit_mode'  =>  $scoTracking->getExitMode(),
-            'lesson_location'  =>  $scoTracking->getLessonLocation(),
-            'lesson_mode'  =>  $scoTracking->getLessonMode(),
-            'is_locked'  =>  $scoTracking->getIsLocked(),
-            'details'  =>  $scoTracking->getDetails(),
-            'latest_date'  =>  $scoTracking->getLatestDate(),
-            'created_at'  =>  Carbon::now(),
-            'updated_at'  =>  Carbon::now(),
-        ]);
+        $this->hydrateTrackingFromModel($tracking, $stored);
 
-        $scoTracking->setUuid($storeTracking->uuid);
-        $scoTracking->setProgression($storeTracking->progression);
-        $scoTracking->setScoreRaw($storeTracking->score_raw);
-        $scoTracking->setScoreMin($storeTracking->score_min);
-        $scoTracking->setScoreMax($storeTracking->score_max);
-        $scoTracking->setScoreScaled($storeTracking->score_scaled);
-        $scoTracking->setLessonStatus($storeTracking->lesson_status);
-        $scoTracking->setCompletionStatus($storeTracking->completion_status);
-        $scoTracking->setSessionTime($storeTracking->session_time);
-        $scoTracking->setTotalTimeInt($storeTracking->total_time_int);
-        $scoTracking->setTotalTimeString($storeTracking->total_time_string);
-        $scoTracking->setEntry($storeTracking->entry);
-        $scoTracking->setSuspendData($storeTracking->suspend_data);
-        $scoTracking->setCredit($storeTracking->credit);
-        $scoTracking->setExitMode($storeTracking->exit_mode);
-        $scoTracking->setLessonLocation($storeTracking->lesson_location);
-        $scoTracking->setLessonMode($storeTracking->lesson_mode);
-        $scoTracking->setIsLocked($storeTracking->is_locked);
-        $scoTracking->setDetails($storeTracking->details);
-        $scoTracking->setLatestDate(Carbon::parse($storeTracking->latest_date));
-
-        return $scoTracking;
+        return $tracking;
     }
 
-    public function findScoTrackingId($scoUuid, $scoTrackingUuid)
-    {
-        return ScormScoTrackingModel::with([
-            'sco'
-        ])->whereHas('sco', function (Builder $query) use ($scoUuid) {
-            $query->where('uuid', $scoUuid);
-        })->where('uuid', $scoTrackingUuid)
-            ->firstOrFail();
-    }
-
-    public function checkUserIsCompletedScorm($scormId, $userId)
-    {
-
-        $completedSco    =   [];
-        $scos   =   ScormScoModel::where('scorm_id', $scormId)->get();
-
-        foreach ($scos as $sco) {
-            $scoTracking    =   ScormScoTrackingModel::where('sco_id', $sco->id)->where('user_id', $userId)->first();
-
-            if ($scoTracking && ($scoTracking->lesson_status == 'passed' || $scoTracking->lesson_status == 'completed')) {
-                $completedSco[] =   true;
-            }
-        }
-
-        if (count($completedSco) == $scos->count()) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    public function updateScoTracking($scoUuid, $userId, $data)
+    public function updateScoTracking(string $scoUuid, mixed $userId, array $data): ScormScoTrackingModel
     {
         $tracking = $this->createScoTracking($scoUuid, $userId);
         $tracking->setLatestDate(Carbon::now());
-        $sco    =   $tracking->getSco();
-        $scorm  =   ScormModel::where('id', $sco['scorm_id'])->firstOrFail();
 
-        $statusPriority = [
-            'unknown' => 0,
-            'not attempted' => 1,
-            'browsed' => 2,
-            'incomplete' => 3,
-            'completed' => 4,
-            'failed' => 5,
-            'passed' => 6,
-        ];
+        $sco   = $tracking->getSco();
+        $scorm = ScormModel::where('id', $sco['scorm_id'])->firstOrFail();
 
-        switch ($scorm->version) {
-            case Scorm::SCORM_12:
-                if (isset($data['cmi.suspend_data']) && !empty($data['cmi.suspend_data'])) {
-                    $tracking->setSuspendData($data['cmi.suspend_data']);
-                }
+        match ($scorm->version) {
+            Scorm::SCORM_12   => $this->applyScorm12Update($tracking, $data),
+            Scorm::SCORM_2004 => $this->applyScorm2004Update($tracking, $data),
+        };
 
-                $scoreRaw = isset($data['cmi.core.score.raw']) ? intval($data['cmi.core.score.raw']) : null;
-                $scoreMin = isset($data['cmi.core.score.min']) ? intval($data['cmi.core.score.min']) : null;
-                $scoreMax = isset($data['cmi.core.score.max']) ? intval($data['cmi.core.score.max']) : null;
-                $lessonStatus = isset($data['cmi.core.lesson_status']) ? $data['cmi.core.lesson_status'] : 'unknown';
-                $sessionTime = isset($data['cmi.core.session_time']) ? $data['cmi.core.session_time'] : null;
-                $sessionTimeInHundredth = $this->convertTimeInHundredth($sessionTime);
-                $progression = !empty($scoreRaw) ? floatval($scoreRaw) : 0;
-                $entry  =   isset($data['cmi.core.entry']) ? $data['cmi.core.entry'] : null;
-                $exit  =   isset($data['cmi.core.exit']) ? $data['cmi.core.exit'] : null;
-                $lessonLocation =   isset($data['cmi.core.lesson_location']) ? $data['cmi.core.lesson_location'] : null;
-                $totalTime  =   isset($data['cmi.core.total_time']) ? $data['cmi.core.total_time'] : 0;
-
-                $tracking->setDetails($data);
-                $tracking->setEntry($entry);
-                $tracking->setExitMode($exit);
-                $tracking->setLessonLocation($lessonLocation);
-                $tracking->setSessionTime($sessionTimeInHundredth);
-
-                // Compute total time
-                $totalTimeInHundredth = $this->convertTimeInHundredth($totalTime);
-                $tracking->setTotalTime($totalTimeInHundredth, Scorm::SCORM_12);
-
-                $bestScore = $tracking->getScoreRaw();
-
-                // Update best score if the current score is better than the previous best score
-
-                if (empty($bestScore) || (!is_null($scoreRaw) && (int)$scoreRaw > (int)$bestScore)) {
-                    $tracking->setScoreRaw($scoreRaw);
-                    $tracking->setScoreMin($scoreMin);
-                    $tracking->setScoreMax($scoreMax);
-                }
-
-                $tracking->setLessonStatus($lessonStatus);
-                $bestStatus = $lessonStatus;
-
-                if (empty($progression) && ('completed' === $bestStatus || 'passed' === $bestStatus)) {
-                    $progression = 100;
-                }
-
-                if ($progression > $tracking->getProgression()) {
-                    $tracking->setProgression($progression);
-                }
-
-                break;
-
-            case Scorm::SCORM_2004:
-                $tracking->setDetails($data);
-
-                if (isset($data['cmi.suspend_data']) && !empty($data['cmi.suspend_data'])) {
-                    $tracking->setSuspendData($data['cmi.suspend_data']);
-                }
-
-                $dataSessionTime = isset($data['cmi.session_time']) ?
-                    $this->formatSessionTime($data['cmi.session_time']) :
-                    'PT0S';
-                $completionStatus = isset($data['cmi.completion_status']) ? $data['cmi.completion_status'] : 'unknown';
-                $successStatus = isset($data['cmi.success_status']) ? $data['cmi.success_status'] : 'unknown';
-                $scoreRaw = isset($data['cmi.score.raw']) ? intval($data['cmi.score.raw']) : null;
-                $scoreMin = isset($data['cmi.score.min']) ? intval($data['cmi.score.min']) : null;
-                $scoreMax = isset($data['cmi.score.max']) ? intval($data['cmi.score.max']) : null;
-                $scoreScaled = isset($data['cmi.score.scaled']) ? floatval($data['cmi.score.scaled']) : null;
-                $progression = isset($data['cmi.progress_measure']) ? floatval($data['cmi.progress_measure']) : 0;
-                $bestScore = $tracking->getScoreRaw();
-
-                // Computes total time
-                $totalTime = new \DateInterval($tracking->getTotalTimeString());
-
-                try {
-                    $sessionTime = new \DateInterval($dataSessionTime);
-                } catch (\Exception $e) {
-                    $sessionTime = new \DateInterval('PT0S');
-                }
-                $computedTime = new \DateTime();
-                $computedTime->setTimestamp(0);
-                $computedTime->add($totalTime);
-                $computedTime->add($sessionTime);
-                $computedTimeInSecond = $computedTime->getTimestamp();
-                $totalTimeInterval = $this->retrieveIntervalFromSeconds($computedTimeInSecond);
-                $data['cmi.total_time'] = $totalTimeInterval;
-                $tracking->setTotalTimeString($totalTimeInterval);
-
-                // Update best score if the current score is better than the previous best score
-                if (empty($bestScore) || (!is_null($scoreRaw) && (int)$scoreRaw > (int)$bestScore)) {
-                    $tracking->setScoreRaw($scoreRaw);
-                    $tracking->setScoreMin($scoreMin);
-                    $tracking->setScoreMax($scoreMax);
-                    $tracking->setScoreScaled($scoreScaled);
-                }
-
-                // Update best success status and completion status
-                $lessonStatus = $completionStatus;
-                if (in_array($successStatus, ['passed', 'failed'])) {
-                    $lessonStatus = $successStatus;
-                }
-
-                $tracking->setLessonStatus($lessonStatus);
-                $bestStatus = $lessonStatus;
-
-                if (
-                    empty($tracking->getCompletionStatus())
-                    || ($completionStatus !== $tracking->getCompletionStatus() && $statusPriority[$completionStatus] > $statusPriority[$tracking->getCompletionStatus()])
-                ) {
-                    // This is no longer needed as completionStatus and successStatus are merged together
-                    // I keep it for now for possible retro compatibility
-                    $tracking->setCompletionStatus($completionStatus);
-                }
-
-                if (empty($progression) && ('completed' === $bestStatus || 'passed' === $bestStatus)) {
-                    $progression = 100;
-                }
-
-                if ($progression > $tracking->getProgression()) {
-                    $tracking->setProgression($progression);
-                }
-
-                break;
-        }
-
-        $updateResult   =   ScormScoTrackingModel::where('user_id', $tracking->getUserId())
+        $row = ScormScoTrackingModel::where('user_id', $tracking->getUserId())
             ->where('sco_id', $sco['id'])
             ->firstOrFail();
 
-        $updateResult->progression  =   $tracking->getProgression();
-        $updateResult->score_raw    =   $tracking->getScoreRaw();
-        $updateResult->score_min    =   $tracking->getScoreMin();
-        $updateResult->score_max    =   $tracking->getScoreMax();
-        $updateResult->score_scaled    =   $tracking->getScoreScaled();
-        $updateResult->lesson_status    =   $tracking->getLessonStatus();
-        $updateResult->completion_status    =   $tracking->getCompletionStatus();
-        $updateResult->session_time    =   $tracking->getSessionTime();
-        $updateResult->total_time_int    =   $tracking->getTotalTimeInt();
-        $updateResult->total_time_string    =   $tracking->getTotalTimeString();
-        $updateResult->entry    =   $tracking->getEntry();
-        $updateResult->suspend_data    =   $tracking->getSuspendData();
-        $updateResult->exit_mode    =   $tracking->getExitMode();
-        $updateResult->credit    =   $tracking->getCredit();
-        $updateResult->lesson_location    =   $tracking->getLessonLocation();
-        $updateResult->lesson_mode    =   $tracking->getLessonMode();
-        $updateResult->is_locked    =   $tracking->getIsLocked();
-        $updateResult->details    =   $tracking->getDetails();
-        $updateResult->latest_date    =   $tracking->getLatestDate();
+        $row->fill([
+            'progression'       => $tracking->getProgression(),
+            'score_raw'         => $tracking->getScoreRaw(),
+            'score_min'         => $tracking->getScoreMin(),
+            'score_max'         => $tracking->getScoreMax(),
+            'score_scaled'      => $tracking->getScoreScaled(),
+            'lesson_status'     => $tracking->getLessonStatus(),
+            'completion_status' => $tracking->getCompletionStatus(),
+            'session_time'      => $tracking->getSessionTime(),
+            'total_time_int'    => $tracking->getTotalTimeInt(),
+            'total_time_string' => $tracking->getTotalTimeString(),
+            'entry'             => $tracking->getEntry(),
+            'suspend_data'      => $tracking->getSuspendData(),
+            'exit_mode'         => $tracking->getExitMode(),
+            'credit'            => $tracking->getCredit(),
+            'lesson_location'   => $tracking->getLessonLocation(),
+            'lesson_mode'       => $tracking->getLessonMode(),
+            'is_locked'         => $tracking->getIsLocked(),
+            'details'           => $tracking->getDetails(),
+            'latest_date'       => $tracking->getLatestDate(),
+        ])->save();
 
-        $updateResult->save();
-
-        return $updateResult;
+        return $row;
     }
 
-    public function resetUserData($scormId, $userId)
+    public function findScoTrackingId(string $scoUuid, string $trackingUuid): ScormScoTrackingModel
     {
-        $scos   =   ScormScoModel::where('scorm_id', $scormId)->get();
+        return ScormScoTrackingModel::with('sco')
+            ->whereHas('sco', fn(Builder $q) => $q->where('uuid', $scoUuid))
+            ->where('uuid', $trackingUuid)
+            ->firstOrFail();
+    }
 
-        foreach ($scos as $sco) {
-            $scoTracking    =   ScormScoTrackingModel::where('sco_id', $sco->id)->where('user_id', $userId)->delete();
+    public function checkUserIsCompletedScorm(int $scormId, mixed $userId): bool
+    {
+        $scos = ScormScoModel::where('scorm_id', $scormId)->get();
+
+        $completed = $scos->filter(function (ScormScoModel $sco) use ($userId) {
+            $tracking = ScormScoTrackingModel::where('sco_id', $sco->id)
+                ->where('user_id', $userId)
+                ->first();
+            return $tracking && in_array($tracking->lesson_status, ['passed', 'completed'], true);
+        });
+
+        return $completed->count() === $scos->count();
+    }
+
+    public function resetUserData(int $scormId, mixed $userId): void
+    {
+        ScormScoModel::where('scorm_id', $scormId)
+            ->get()
+            ->each(function (ScormScoModel $sco) use ($userId) {
+                ScormScoTrackingModel::where('sco_id', $sco->id)->where('user_id', $userId)->delete();
+            });
+    }
+
+    // -------------------------------------------------------------------------
+    // Private — persistence
+    // -------------------------------------------------------------------------
+
+    private function persistScorm(string $uuid, string $filename, int $packageSize): ScormModel
+    {
+        $scormData = $this->scormDisk->loadMetadata($uuid);
+
+        if (empty($scormData['identifier']) || empty($scormData['scos'])) {
+            $this->rollbackAndFail($uuid, 'invalid_scorm_data');
+        }
+
+        $scorm = ScormModel::where('uuid', $uuid)->first();
+
+        if ($scorm) {
+            $this->deleteScormData($scorm);
+        } else {
+            $scorm = new ScormModel();
+        }
+
+        $scorm->fill([
+            'uuid'       => $uuid,
+            'title'      => $scormData['title'],
+            'version'    => $scormData['version'],
+            'entry_url'  => $scormData['entryUrl'],
+            'identifier' => $scormData['identifier'],
+            'origin_file' => $filename,
+            'metadata'   => [
+                'package_size' => $packageSize,
+                'created_at'   => $scormData['created_at'] ?? null,
+                'created_by'   => $scormData['created_by'] ?? null,
+            ],
+        ])->save();
+
+        foreach ($scormData['scos'] as $scoData) {
+            $this->saveScoRecursive($scorm->id, $scoData);
+        }
+
+        return $scorm;
+    }
+
+    private function saveScoRecursive(int $scormId, Sco $scoData, ?int $parentId = null): ScormScoModel
+    {
+        $sco = $this->saveSco($scormId, $scoData, $parentId);
+
+        foreach ($scoData->scoChildren ?? [] as $child) {
+            $this->saveScoRecursive($scormId, $child, $sco->id);
+        }
+
+        return $sco;
+    }
+
+    private function saveSco(int $scormId, Sco $scoData, ?int $parentId): ScormScoModel
+    {
+        $sco = new ScormScoModel();
+        $sco->fill([
+            'scorm_id'           => $scormId,
+            'uuid'               => $scoData->uuid,
+            'sco_parent_id'      => $parentId,
+            'entry_url'          => $scoData->entryUrl,
+            'identifier'         => $scoData->identifier,
+            'title'              => $scoData->title,
+            'visible'            => $scoData->visible,
+            'sco_parameters'     => $scoData->parameters,
+            'launch_data'        => $scoData->launchData,
+            'max_time_allowed'   => $scoData->maxTimeAllowed,
+            'time_limit_action'  => $scoData->timeLimitAction,
+            'block'              => $scoData->block,
+            'score_int'          => $scoData->scoreToPassInt,
+            'score_decimal'      => $scoData->scoreToPassDecimal,
+            'completion_threshold' => $scoData->completionThreshold,
+            'prerequisites'      => $scoData->prerequisites,
+        ])->save();
+
+        return $sco;
+    }
+
+    private function deleteScormData(ScormModel $model): void
+    {
+        foreach ($model->scos()->get() as $sco) {
+            $sco->scoTrackings()->delete();
+        }
+        $model->scos()->delete();
+        $this->scormDisk->deleteScorm($model->uuid);
+    }
+
+    private function rollbackAndFail(string $uuid, string $message): never
+    {
+        $this->scormDisk->deleteScorm($uuid);
+        throw new InvalidScormArchiveException($message);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private — tracking initialisation
+    // -------------------------------------------------------------------------
+
+    private function initScorm12Tracking(ScoTracking $tracking, ScormScoModel $sco, mixed $userId, ?string $userName): array
+    {
+        $tracking->setLessonStatus('not attempted');
+        $tracking->setSuspendData('');
+        $tracking->setEntry('ab-initio');
+        $tracking->setLessonLocation('');
+        $tracking->setCredit('no-credit');
+        $tracking->setTotalTimeInt(0);
+        $tracking->setSessionTime(0);
+        $tracking->setLessonMode('normal');
+        $tracking->setExitMode('');
+        $tracking->setIsLocked($sco->prerequisites !== null);
+
+        return [
+            'cmi.core.entry'        => $tracking->getEntry(),
+            'cmi.core.student_id'   => $userId,
+            'cmi.core.student_name' => $userName,
+        ];
+    }
+
+    private function initScorm2004Tracking(ScoTracking $tracking, mixed $userId, ?string $userName): array
+    {
+        $tracking->setTotalTimeString('PT0S');
+        $tracking->setCompletionStatus('unknown');
+        $tracking->setLessonStatus('unknown');
+        $tracking->setIsLocked(false);
+
+        return [
+            'cmi.entry'               => 'ab-initio',
+            'cmi.learner_id'          => $userId,
+            'cmi.learner_name'        => $userName,
+            'cmi.scaled_passing_score' => 0.5,
+        ];
+    }
+
+    private function hydrateTrackingFromModel(ScoTracking $tracking, ScormScoTrackingModel $model): void
+    {
+        $tracking->setUuid($model->uuid);
+        $tracking->setProgression($model->progression);
+        $tracking->setScoreRaw($model->score_raw);
+        $tracking->setScoreMin($model->score_min);
+        $tracking->setScoreMax($model->score_max);
+        $tracking->setScoreScaled($model->score_scaled);
+        $tracking->setLessonStatus($model->lesson_status);
+        $tracking->setCompletionStatus($model->completion_status);
+        $tracking->setSessionTime($model->session_time);
+        $tracking->setTotalTimeInt($model->total_time_int);
+        $tracking->setTotalTimeString($model->total_time_string);
+        $tracking->setEntry($model->entry);
+        $tracking->setSuspendData($model->suspend_data);
+        $tracking->setCredit($model->credit);
+        $tracking->setExitMode($model->exit_mode);
+        $tracking->setLessonLocation($model->lesson_location);
+        $tracking->setLessonMode($model->lesson_mode);
+        $tracking->setIsLocked($model->is_locked);
+        $tracking->setDetails($model->details);
+        $tracking->setLatestDate(Carbon::parse($model->latest_date));
+    }
+
+    // -------------------------------------------------------------------------
+    // Private — tracking updates
+    // -------------------------------------------------------------------------
+
+    private function applyScorm12Update(ScoTracking $tracking, array $data): void
+    {
+        $tracking->setDetails($data);
+
+        if (!empty($data['cmi.suspend_data'])) {
+            $tracking->setSuspendData($data['cmi.suspend_data']);
+        }
+
+        $scoreRaw   = isset($data['cmi.core.score.raw']) ? (int) $data['cmi.core.score.raw'] : null;
+        $scoreMin   = isset($data['cmi.core.score.min']) ? (int) $data['cmi.core.score.min'] : null;
+        $scoreMax   = isset($data['cmi.core.score.max']) ? (int) $data['cmi.core.score.max'] : null;
+        $status     = $data['cmi.core.lesson_status'] ?? 'unknown';
+        $sessionTime = $this->convertTimeToHundredths($data['cmi.core.session_time'] ?? null);
+        $totalTime   = $this->convertTimeToHundredths($data['cmi.core.total_time'] ?? '0:0:0');
+
+        $tracking->setEntry($data['cmi.core.entry'] ?? null);
+        $tracking->setExitMode($data['cmi.core.exit'] ?? null);
+        $tracking->setLessonLocation($data['cmi.core.lesson_location'] ?? null);
+        $tracking->setSessionTime($sessionTime);
+        $tracking->setTotalTime($totalTime, Scorm::SCORM_12);
+        $tracking->setLessonStatus($status);
+
+        if (empty($tracking->getScoreRaw()) || (!is_null($scoreRaw) && $scoreRaw > (int) $tracking->getScoreRaw())) {
+            $tracking->setScoreRaw($scoreRaw);
+            $tracking->setScoreMin($scoreMin);
+            $tracking->setScoreMax($scoreMax);
+        }
+
+        $progression = !empty($scoreRaw) ? (float) $scoreRaw : 0;
+        if ($progression === 0.0 && in_array($status, ['completed', 'passed'], true)) {
+            $progression = 100;
+        }
+        if ($progression > $tracking->getProgression()) {
+            $tracking->setProgression($progression);
         }
     }
 
-    private function convertTimeInHundredth($time)
+    private function applyScorm2004Update(ScoTracking $tracking, array $data): void
     {
-        if ($time != null) {
-            $timeInArray = explode(':', $time);
-            $timeInArraySec = explode('.', $timeInArray[2]);
-            $timeInHundredth = 0;
+        $tracking->setDetails($data);
 
-            if (isset($timeInArraySec[1])) {
-                if (1 === strlen($timeInArraySec[1])) {
-                    $timeInArraySec[1] .= '0';
-                }
-                $timeInHundredth = intval($timeInArraySec[1]);
-            }
-            $timeInHundredth += intval($timeInArraySec[0]) * 100;
-            $timeInHundredth += intval($timeInArray[1]) * 6000;
-            $timeInHundredth += intval($timeInArray[0]) * 360000;
+        if (!empty($data['cmi.suspend_data'])) {
+            $tracking->setSuspendData($data['cmi.suspend_data']);
+        }
 
-            return $timeInHundredth;
-        } else {
+        $sessionTimeStr  = $this->normalizeIso8601Duration($data['cmi.session_time'] ?? 'PT0S');
+        $completionStatus = $data['cmi.completion_status'] ?? 'unknown';
+        $successStatus    = $data['cmi.success_status'] ?? 'unknown';
+        $scoreRaw         = isset($data['cmi.score.raw'])    ? (int)   $data['cmi.score.raw']    : null;
+        $scoreMin         = isset($data['cmi.score.min'])    ? (int)   $data['cmi.score.min']    : null;
+        $scoreMax         = isset($data['cmi.score.max'])    ? (int)   $data['cmi.score.max']    : null;
+        $scoreScaled      = isset($data['cmi.score.scaled']) ? (float) $data['cmi.score.scaled'] : null;
+        $progression      = isset($data['cmi.progress_measure']) ? (float) $data['cmi.progress_measure'] : 0;
+
+        // Accumulate total time
+        $totalTime   = new DateInterval($tracking->getTotalTimeString());
+        try {
+            $sessionTime = new DateInterval($sessionTimeStr);
+        } catch (Exception) {
+            $sessionTime = new DateInterval('PT0S');
+        }
+        $base = new DateTime('@0');
+        $base->add($totalTime)->add($sessionTime);
+        $totalTimeInterval = $this->secondsToIsoDuration($base->getTimestamp());
+        $data['cmi.total_time'] = $totalTimeInterval;
+        $tracking->setTotalTimeString($totalTimeInterval);
+
+        if (empty($tracking->getScoreRaw()) || (!is_null($scoreRaw) && $scoreRaw > (int) $tracking->getScoreRaw())) {
+            $tracking->setScoreRaw($scoreRaw);
+            $tracking->setScoreMin($scoreMin);
+            $tracking->setScoreMax($scoreMax);
+            $tracking->setScoreScaled($scoreScaled);
+        }
+
+        $lessonStatus = in_array($successStatus, ['passed', 'failed'], true) ? $successStatus : $completionStatus;
+        $tracking->setLessonStatus($lessonStatus);
+        $tracking->setCompletionStatus($completionStatus);
+
+        if ($progression === 0.0 && in_array($lessonStatus, ['completed', 'passed'], true)) {
+            $progression = 100;
+        }
+        if ($progression > $tracking->getProgression()) {
+            $tracking->setProgression($progression);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private — time utilities
+    // -------------------------------------------------------------------------
+
+    /**
+     * Convert a SCORM 1.2 HH:MM:SS.ss time string to hundredths of a second.
+     */
+    private function convertTimeToHundredths(?string $time): int
+    {
+        if ($time === null || $time === '') {
             return 0;
         }
+
+        [$h, $m, $rest] = explode(':', $time);
+        [$s, $cs]       = array_pad(explode('.', $rest), 2, '0');
+
+        if (strlen($cs) === 1) {
+            $cs .= '0';
+        }
+
+        return (int) $h * 360000
+            + (int) $m * 6000
+            + (int) $s * 100
+            + (int) $cs;
     }
 
     /**
-     * Converts a time in seconds to a DateInterval string.
-     *
-     * @param int $seconds
-     *
-     * @return string
+     * Convert a total number of seconds to a SCORM 2004 ISO 8601 duration string.
      */
-    private function retrieveIntervalFromSeconds($seconds)
+    private function secondsToIsoDuration(int $seconds): string
     {
-        $result = '';
-        $remainingTime = (int) $seconds;
-
-        if (empty($remainingTime)) {
-            $result .= 'PT0S';
-        } else {
-            $nbDays = (int) ($remainingTime / 86400);
-            $remainingTime %= 86400;
-            $nbHours = (int) ($remainingTime / 3600);
-            $remainingTime %= 3600;
-            $nbMinutes = (int) ($remainingTime / 60);
-            $nbSeconds = $remainingTime % 60;
-            $result .= 'P' . $nbDays . 'DT' . $nbHours . 'H' . $nbMinutes . 'M' . $nbSeconds . 'S';
+        if ($seconds === 0) {
+            return 'PT0S';
         }
 
-        return $result;
-    }
+        $d  = intdiv($seconds, 86400);
+        $seconds %= 86400;
+        $h  = intdiv($seconds, 3600);
+        $seconds %= 3600;
+        $m  = intdiv($seconds, 60);
+        $s  = $seconds % 60;
 
-    private function formatSessionTime($sessionTime)
-    {
-        $formattedValue = 'PT0S';
-        $generalPattern = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?([0-9]+S)?$/';
-        $decimalPattern = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?[0-9]+\.[0-9]{1,2}S$/';
-
-        if ('PT' !== $sessionTime) {
-            if (preg_match($generalPattern, $sessionTime)) {
-                $formattedValue = $sessionTime;
-            } elseif (preg_match($decimalPattern, $sessionTime)) {
-                $formattedValue = preg_replace(['/\.[0-9]+S$/'], ['S'], $sessionTime);
-            }
-        }
-
-        return $formattedValue;
+        return "P{$d}DT{$h}H{$m}M{$s}S";
     }
 
     /**
-     * Get file size in bytes
-     * 
-     * @param string|UploadedFile $file
-     * @return int
+     * Normalise a SCORM 2004 session time string to a valid ISO 8601 duration,
+     * stripping decimal seconds that PHP's DateInterval does not support.
      */
-    private function getFileSize($file)
+    private function normalizeIso8601Duration(string $value): string
     {
-        if ($file instanceof UploadedFile) {
-            return $file->getSize();
+        if ($value === 'PT') {
+            return 'PT0S';
         }
 
-        if (is_string($file) && file_exists($file)) {
-            return filesize($file);
+        // Full integer duration
+        if (preg_match('/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?([0-9]+S)?$/', $value)) {
+            return $value;
         }
 
-        return 0;
-    }
-
-    /**
-     * Extract creation date from SCORM manifest metadata following SCORM standards
-     */
-    private function extractCreationDate(DOMDocument $dom)
-    {
-        try {
-            $xpath = new \DOMXPath($dom);
-
-            // Register common SCORM namespaces with error handling
-            $this->registerScormNamespaces($xpath);
-
-            // SCORM 2004: Look for lom:lom/lom:lifeCycle/lom:contribute/lom:date/lom:dateTime
-            // Priority 1: Creator/Author contribution date
-            $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime[ancestor::lom:contribute[lom:role/lom:value[text()="creator" or text()="author"]]]');
-            if ($dateNodes && $dateNodes->length > 0) {
-                return $this->formatDate($dateNodes->item(0)->textContent);
-            }
-
-            // Priority 2: Any contribution date
-            $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime[ancestor::lom:contribute]');
-            if ($dateNodes && $dateNodes->length > 0) {
-                return $this->formatDate($dateNodes->item(0)->textContent);
-            }
-
-            // Priority 3: Any dateTime in metadata
-            $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime');
-            if ($dateNodes && $dateNodes->length > 0) {
-                return $this->formatDate($dateNodes->item(0)->textContent);
-            }
-
-            // SCORM 1.2: Look for <schema> and <schemaversion> to get creation context
-            $schemaNodes = $this->safeXPathQuery($xpath, '//schema');
-            if ($schemaNodes && $schemaNodes->length > 0) {
-                $schema = $schemaNodes->item(0)->textContent;
-                if (strpos($schema, 'ADL SCORM') !== false) {
-                    // For SCORM 1.2, we might not have creation date in manifest
-                    // Return null as it's not standard in SCORM 1.2
-                    return null;
-                }
-            }
-        } catch (\Exception $e) {
-            \Log::warning('extractCreationDate: Error extracting creation date - ' . $e->getMessage());
+        // Duration with decimal seconds — strip the fractional part
+        if (preg_match('/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?[0-9]+\.[0-9]{1,2}S$/', $value)) {
+            return preg_replace('/\.[0-9]+S$/', 'S', $value);
         }
 
-        return null;
-    }
-
-    /**
-     * Extract creator from SCORM manifest metadata following SCORM standards
-     */
-    private function extractCreator(DOMDocument $dom)
-    {
-        try {
-            $xpath = new \DOMXPath($dom);
-
-            // Register common SCORM namespaces with error handling
-            $this->registerScormNamespaces($xpath);
-
-            // SCORM 2004: Look for lom:lom/lom:lifeCycle/lom:contribute/lom:entity
-            // Priority 1: Creator role
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="creator"]]]');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // Priority 2: Author role
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="author"]]]');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // Priority 3: Publisher role
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="publisher"]]]');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // Priority 4: Any entity in contribute section
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute]');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // Priority 5: Any entity in metadata
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // SCORM 1.2: Look for organization or other creator information
-            // SCORM 1.2 typically doesn't have detailed creator metadata
-            $orgNodes = $this->safeXPathQuery($xpath, '//organization');
-            if ($orgNodes && $orgNodes->length > 0) {
-                // For SCORM 1.2, we might not have creator info in manifest
-                return null;
-            }
-        } catch (\Exception $e) {
-            \Log::warning('extractCreator: Error extracting creator - ' . $e->getMessage());
-        }
-
-        return null;
-    }
-
-    /**
-     * Format date string to ISO 8601 format
-     */
-    private function formatDate($dateString)
-    {
-        if (empty($dateString)) {
-            return null;
-        }
-
-        // Try to parse the date and convert to ISO 8601
-        try {
-            $date = new \DateTime($dateString);
-            return $date->format('c'); // ISO 8601 format
-        } catch (\Exception $e) {
-            // If parsing fails, return the original string
-            return trim($dateString);
-        }
-    }
-
-    /**
-     * Register SCORM namespaces safely
-     */
-    private function registerScormNamespaces(\DOMXPath $xpath)
-    {
-        try {
-            $xpath->registerNamespace('lom', 'http://ltsc.ieee.org/xsd/LOM');
-            $xpath->registerNamespace('adlcp', 'http://www.adlnet.org/xsd/adlcp_v1p3');
-            $xpath->registerNamespace('adlseq', 'http://www.adlnet.org/xsd/adlseq_v1p3');
-            $xpath->registerNamespace('adlnav', 'http://www.adlnet.org/xsd/adlnav_v1p3');
-        } catch (\Exception $e) {
-            \Log::warning('registerScormNamespaces: Error registering namespaces - ' . $e->getMessage());
-        }
-    }
-
-    /**
-     * Execute XPath query safely with error handling
-     */
-    private function safeXPathQuery(\DOMXPath $xpath, $query)
-    {
-        try {
-            return $xpath->query($query);
-        } catch (\Exception $e) {
-            \Log::warning('safeXPathQuery: Error executing XPath query "' . $query . '" - ' . $e->getMessage());
-            return false;
-        }
-    }
-
-    /**
-     * Fix XML entities by escaping unescaped ampersands while preserving CDATA sections
-     * 
-     * @param string $xml
-     * @return string
-     */
-    private function fixXmlEntities($xml)
-    {
-        // Extract CDATA sections with placeholders
-        $cdataSections = [];
-        $xml = preg_replace_callback(
-            '/<!\[CDATA\[(.*?)\]\]>/s',
-            function ($matches) use (&$cdataSections) {
-                $placeholder = '__CDATA_' . count($cdataSections) . '__';
-                $cdataSections[$placeholder] = $matches[0];
-                return $placeholder;
-            },
-            $xml
-        );
-
-        // Escape ampersands not part of valid XML entities
-        // Valid: &name; &#123; &#xAB; &#XAB;
-        $xml = preg_replace('/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);)/', '&amp;', $xml);
-
-        // Restore CDATA sections
-        return str_replace(array_keys($cdataSections), $cdataSections, $xml);
-    }
-
-    /**
-     * Clean resources and throw exception.
-     */
-    private function onError($msg)
-    {
-        $this->scormDisk->deleteScorm($this->uuid);
-        throw new InvalidScormArchiveException($msg);
+        return 'PT0S';
     }
 }

--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -1,17 +1,14 @@
 <?php
 
+
 namespace Peopleaps\Scorm\Manager;
 
 use Carbon\Carbon;
-use DateInterval;
-use DateTime;
 use DOMDocument;
-use DOMXPath;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Peopleaps\Scorm\Entity\Scorm;
-use Peopleaps\Scorm\Entity\Sco;
 use Peopleaps\Scorm\Entity\ScoTracking;
 use Peopleaps\Scorm\Exception\InvalidScormArchiveException;
 use Peopleaps\Scorm\Library\ScormLib;
@@ -19,125 +16,481 @@ use Peopleaps\Scorm\Model\ScormModel;
 use Peopleaps\Scorm\Model\ScormScoModel;
 use Peopleaps\Scorm\Model\ScormScoTrackingModel;
 use Illuminate\Support\Str;
-use ZipArchive;
-use Illuminate\Support\Facades\Log;
+use Peopleaps\Scorm\Entity\Sco;
 
 class ScormManager
 {
-    private ScormLib  $scormLib;
-    private ScormDisk $scormDisk;
+    /** @var ScormLib */
+    private $scormLib;
+    /** @var ScormDisk */
+    private $scormDisk;
+    /** @var string $uuid */
+    private $uuid;
 
     /**
-     * The UUID for the current upload operation.
-     * Scoped per-call via uploadScormArchive / uploadScormFromUri
-     * so the class is safe to reuse across requests.
+     * Constructor.
+     *
+     * @param string $filesDir
+     * @param string $uploadDir
      */
-    private string $uuid;
-
-    // -------------------------------------------------------------------------
-    // SCORM status priority for comparison logic
-    // -------------------------------------------------------------------------
-
-    private const STATUS_PRIORITY = [
-        'unknown'       => 0,
-        'not attempted' => 1,
-        'browsed'       => 2,
-        'incomplete'    => 3,
-        'completed'     => 4,
-        'failed'        => 5,
-        'passed'        => 6,
-    ];
-
     public function __construct()
     {
-        $this->scormLib  = new ScormLib();
+        $this->scormLib = new ScormLib();
         $this->scormDisk = new ScormDisk();
     }
 
-    // =========================================================================
-    // Upload
-    // =========================================================================
-
-    /**
-     * Upload a SCORM package that already lives on the archive S3 bucket.
-     *
-     * @param  string       $file  S3 object key inside the archive bucket.
-     * @param  string|null  $uuid  Supply an existing UUID to replace that package.
-     * @return ScormModel
-     */
-    public function uploadScormFromUri(string $file, ?string $uuid = null): ScormModel
+    public function uploadScormFromUri($file, $uuid = null)
     {
+        // $uuid is meant for user to update scorm content. Hence, if user want to update content should parse in existing uuid
+        $this->uuid =  $uuid ?? Str::uuid()->toString();
+
+        // Validate that the file parameter is not empty
         if (empty($file)) {
             throw new InvalidScormArchiveException('file_parameter_empty');
         }
 
-        $this->uuid = $uuid ?? Str::uuid()->toString();
-
-        Log::info('ScormManager::uploadScormFromUri — processing: ' . $file);
+        // Log the file being processed for debugging
+        \Log::info('Uploading SCORM from URI: ' . $file);
 
         $scorm = null;
-        $this->scormDisk->readScormArchive($file, function (string $tmpPath) use (&$scorm, $file, $uuid) {
-            $scorm = $this->saveScorm($tmpPath, basename($file), $uuid);
+        $this->scormDisk->readScormArchive($file, function ($path) use (&$scorm, $file, $uuid) {
+            $filename = basename($file);
+            $scorm = $this->saveScorm($path, $filename, $uuid);
         });
-
         return $scorm;
     }
 
     /**
-     * Upload a SCORM package from a local/uploaded file.
-     *
-     * @param  UploadedFile  $file
-     * @param  string|null   $uuid  Supply an existing UUID to replace that package.
+     * @param UploadedFile $file
+     * @param null|string $uuid
      * @return ScormModel
+     * @throws InvalidScormArchiveException
      */
-    public function uploadScormArchive(UploadedFile $file, ?string $uuid = null): ScormModel
+    public function uploadScormArchive(UploadedFile $file, $uuid = null)
     {
-        $this->uuid = $uuid ?? Str::uuid()->toString();
+        // $uuid is meant for user to update scorm content. Hence, if user want to update content should parse in existing uuid
+        $this->uuid =  $uuid ?? Str::uuid()->toString();
 
         return $this->saveScorm($file, $file->getClientOriginalName(), $uuid);
     }
 
-    // =========================================================================
-    // SCO / Tracking queries
-    // =========================================================================
+    /**
+     * Find imsmanifest.xml location in ZIP archive
+     * 
+     * @param \ZipArchive $zip
+     * @return array ['found' => bool, 'path' => string, 'stream' => resource|null]
+     */
+    private function findManifestInZip(\ZipArchive $zip)
+    {
+        // Look for imsmanifest.xml in root directory first
+        $manifestStream = $zip->getStream('imsmanifest.xml');
+
+        if ($manifestStream) {
+            \Log::info('Found imsmanifest.xml in root directory');
+            return [
+                'found' => true,
+                'path' => 'imsmanifest.xml',
+                'stream' => $manifestStream
+            ];
+        }
+
+        // Search for imsmanifest.xml in subdirectories
+        \Log::info('imsmanifest.xml not found in root, searching subdirectories...');
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $filename = $zip->getNameIndex($i);
+
+            // Check if this file is imsmanifest.xml (case insensitive)
+            if (strtolower(basename($filename)) === 'imsmanifest.xml') {
+                $manifestStream = $zip->getStream($filename);
+                if ($manifestStream) {
+                    \Log::info('Found imsmanifest.xml at: ' . $filename);
+                    return [
+                        'found' => true,
+                        'path' => $filename,
+                        'stream' => $manifestStream
+                    ];
+                }
+            }
+        }
+
+        return [
+            'found' => false,
+            'path' => '',
+            'stream' => null
+        ];
+    }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Collection<ScormScoModel>
+     *  Checks if it is a valid scorm archive
+     * 
+     * @param string|UploadedFile $file zip.       
      */
-    public function getScos(int $scormId)
+    private function validatePackage($file)
     {
-        return ScormScoModel::with('scorm')->where('scorm_id', $scormId)->get();
+        $zip = new \ZipArchive();
+        $manifestResult = null;
+
+        try {
+            $openValue = $zip->open($file);
+
+            if ($openValue !== true) {
+                \Log::error('Zip open errorCode: ' . $openValue);
+                $this->onError('invalid_scorm_archive_message');
+            }
+
+            $manifestResult = $this->findManifestInZip($zip);
+        } finally {
+            // Always close resources
+            if ($manifestResult && $manifestResult['stream'] && is_resource($manifestResult['stream'])) {
+                fclose($manifestResult['stream']);
+            }
+            $zip->close();
+        }
+
+        if (!$manifestResult['found']) {
+            \Log::error('imsmanifest.xml not found anywhere in the ZIP archive');
+            $this->onError('invalid_scorm_archive_message');
+        }
+
+        \Log::info('SCORM archive validation successful. Manifest found at: ' . $manifestResult['path']);
     }
 
     /**
-     * @return ScormScoModel
+     *  Save scorm data
+     *
+     * @param string|UploadedFile $file zip.
+     * @param string $filename
+     * @param null|string $uuid
+     * @return ScormModel
+     * @throws InvalidScormArchiveException
      */
-    public function getScoByUuid(string $scoUuid): ScormScoModel
+    private function saveScorm($file, $filename, $uuid = null)
     {
-        return ScormScoModel::with('scorm')->where('uuid', $scoUuid)->firstOrFail();
+        $this->validatePackage($file);
+        $scormData  =   $this->generateScorm($file);
+        // save to db
+        if (is_null($scormData) || !is_array($scormData)) {
+            $this->onError('invalid_scorm_data');
+        }
+
+        // This uuid is use when the admin wants to edit existing scorm file.
+        if (!empty($uuid)) {
+            $this->uuid =   $uuid; // Overwrite system generated uuid
+        }
+
+        /**
+         * ScormModel::whereUuid Query Builder style equals ScormModel::where('uuid',$value)
+         * 
+         * From Laravel doc https://laravel.com/docs/5.0/queries#advanced-wheres.
+         * Dynamic Where Clauses
+         * You may even use "dynamic" where statements to fluently build where statements using magic methods:
+         * 
+         * Examples: 
+         * 
+         * $admin = DB::table('users')->whereId(1)->first();
+         * From laravel framework https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Query/Builder.php'
+         *  Handle dynamic method calls into the method.
+         *  return $this->dynamicWhere($method, $parameters);
+         **/
+        // $scorm = ScormModel::whereOriginFile($filename);
+        // Uuid indicator is better than filename for update content or add new content.
+        $scorm = ScormModel::where('uuid', $this->uuid);
+
+        // Check if scom package already exists to drop old one.
+        if (!$scorm->exists()) {
+            $scorm = new ScormModel();
+        } else {
+            $scorm = $scorm->first();
+            $this->deleteScormData($scorm);
+        }
+
+        $scorm->uuid =   $this->uuid;
+        $scorm->title =   $scormData['title'];
+        $scorm->version =   $scormData['version'];
+        $scorm->entry_url =   $scormData['entryUrl'];
+        $scorm->identifier =   $scormData['identifier'];
+        $scorm->origin_file =   $filename;
+
+        // Auto-detect and set metadata
+        $scorm->metadata = [
+            'package_size' => $this->getFileSize($file),
+            'created_at' => $scormData['created_at'] ?? null,
+            'created_by' => $scormData['created_by'] ?? null
+        ];
+
+        $scorm->save();
+
+        if (!empty($scormData['scos']) && is_array($scormData['scos'])) {
+            \Log::info('saveScorm: Saving ' . count($scormData['scos']) . ' SCOs');
+            /** @var Sco $scoData */
+            foreach ($scormData['scos'] as $scoData) {
+                $this->saveScormScosRecursively($scorm->id, $scoData);
+            }
+        } else {
+            \Log::warning('saveScorm: No SCOs to save');
+        }
+
+        return  $scorm;
     }
 
-    public function getUserResult(int $scoId, int $userId): ?ScormScoTrackingModel
+    /**
+     * Save Scorm sco and it's nested children recursively
+     * @param int $scorm_id scorm id.
+     * @param Sco $scoData Sco data to be store.
+     * @param int $sco_parent_id sco parent id for children
+     */
+    private function saveScormScosRecursively($scorm_id, $scoData, $sco_parent_id = null)
     {
-        return ScormScoTrackingModel::where('sco_id', $scoId)
-            ->where('user_id', $userId)
-            ->first();
+        $sco = $this->saveScormScos($scorm_id, $scoData, $sco_parent_id);
+
+        // Recursively save children
+        if ($scoData->scoChildren && is_array($scoData->scoChildren)) {
+            foreach ($scoData->scoChildren as $scoChild) {
+                $this->saveScormScosRecursively($scorm_id, $scoChild, $sco->id);
+            }
+        }
+
+        return $sco;
     }
 
-    // =========================================================================
-    // Tracking
-    // =========================================================================
-
-    public function createScoTracking(string $scoUuid, $userId = null, $userName = null): ScoTracking
+    /**
+     * Save Scorm sco and it's nested children
+     * @param int $scorm_id scorm id.
+     * @param Sco $scoData Sco data to be store.
+     * @param int $sco_parent_id sco parent id for children
+     */
+    private function saveScormScos($scorm_id, $scoData, $sco_parent_id = null)
     {
-        $sco     = ScormScoModel::where('uuid', $scoUuid)->firstOrFail();
+        $sco    =   new ScormScoModel();
+        $sco->scorm_id  =   $scorm_id;
+        $sco->uuid  =   $scoData->uuid;
+        $sco->sco_parent_id  =   $sco_parent_id;
+        $sco->entry_url  =   $scoData->entryUrl;
+        $sco->identifier  =   $scoData->identifier;
+        $sco->title  =   $scoData->title;
+        $sco->visible  =   $scoData->visible;
+        $sco->sco_parameters  =   $scoData->parameters;
+        $sco->launch_data  =   $scoData->launchData;
+        $sco->max_time_allowed  =   $scoData->maxTimeAllowed;
+        $sco->time_limit_action  =   $scoData->timeLimitAction;
+        $sco->block  =   $scoData->block;
+        $sco->score_int  =   $scoData->scoreToPassInt;
+        $sco->score_decimal  =   $scoData->scoreToPassDecimal;
+        $sco->completion_threshold  =   $scoData->completionThreshold;
+        $sco->prerequisites  =   $scoData->prerequisites;
+
+        $sco->save();
+
+        \Log::info("saveScormScos: Saved SCO - " . $sco->identifier);
+        return $sco;
+    }
+
+    /**
+     * @param string|UploadedFile $file zip.       
+     */
+    private function parseScormArchive($file)
+    {
+        $data = [];
+        $contents = '';
+        $zip = new \ZipArchive();
+        $manifestResult = null;
+
+        try {
+            $openValue = $zip->open($file);
+
+            if ($openValue !== true) {
+                \Log::error('Failed to open ZIP file in parseScormArchive. Error code: ' . $openValue);
+                $this->onError('cannot_load_imsmanifest_message');
+            }
+
+            $manifestResult = $this->findManifestInZip($zip);
+
+            if (!$manifestResult['found']) {
+                $this->onError('cannot_load_imsmanifest_message');
+            }
+
+            while (!feof($manifestResult['stream'])) {
+                $contents .= fread($manifestResult['stream'], 2);
+            }
+        } finally {
+            // Always close resources
+            if ($manifestResult && $manifestResult['stream'] && is_resource($manifestResult['stream'])) {
+                fclose($manifestResult['stream']);
+            }
+            $zip->close();
+        }
+
+        $dom = new DOMDocument();
+
+        // Fix XML entity errors by escaping unescaped ampersands
+        $contents = $this->fixXmlEntities($contents);
+
+        if (!$dom->loadXML($contents)) {
+            $this->onError('cannot_load_imsmanifest_message');
+        }
+
+        $manifest = $dom->getElementsByTagName('manifest')->item(0);
+        if (!is_null($manifest->attributes->getNamedItem('identifier'))) {
+            $data['identifier'] = $manifest->attributes->getNamedItem('identifier')->nodeValue;
+        } else {
+            $this->onError('invalid_scorm_manifest_identifier');
+        }
+        $titles = $dom->getElementsByTagName('title');
+        if ($titles->length > 0) {
+            $data['title'] = Str::of($titles->item(0)->textContent)->trim('/n')->trim();
+        }
+
+        $scormVersionElements = $dom->getElementsByTagName('schemaversion');
+        if ($scormVersionElements->length > 0) {
+            switch ($scormVersionElements->item(0)->textContent) {
+                case '1.2':
+                    $data['version'] = Scorm::SCORM_12;
+                    break;
+                case 'CAM 1.3':
+                case '2004 3rd Edition':
+                case '2004 4th Edition':
+                    $data['version'] = Scorm::SCORM_2004;
+                    break;
+                default:
+                    $this->onError('invalid_scorm_version_message');
+            }
+        } else {
+            $this->onError('invalid_scorm_version_message');
+        }
+        $scos = $this->scormLib->parseOrganizationsNode($dom);
+
+        if (0 >= count($scos)) {
+            \Log::error('parseScormArchive: No SCOs found in SCORM archive');
+            $this->onError('no_sco_in_scorm_archive_message');
+        }
+
+        $data['entryUrl'] = $scos[0]->entryUrl ?? $scos[0]->scoChildren[0]->entryUrl;
+        $data['scos'] = $scos;
+
+        \Log::info('parseScormArchive: Found ' . count($scos) . ' SCOs, entryUrl: ' . $data['entryUrl']);
+
+        // Include manifest path for later use in entry URL adjustment
+        $data['manifestPath'] = $manifestResult['path'];
+
+        // Extract creation date and creator from manifest metadata
+        $data['created_at'] = $this->extractCreationDate($dom);
+        $data['created_by'] = $this->extractCreator($dom);
+
+        return $data;
+    }
+
+    public function deleteScorm($model)
+    {
+        // Delete after the previous item is stored
+        if ($model) {
+            $this->deleteScormData($model);
+            $model->delete(); // delete scorm
+        }
+    }
+
+    private function deleteScormData($model)
+    {
+        // Delete after the previous item is stored
+        $oldScos = $model->scos()->get();
+
+        // Delete all tracking associate with sco
+        foreach ($oldScos as $oldSco) {
+            $oldSco->scoTrackings()->delete();
+        }
+        $model->scos()->delete(); // delete scos
+        // Delete folder from server
+        $this->deleteScormFolder($model->uuid);
+    }
+
+    /**
+     * @param $folderHashedName
+     * @return bool
+     */
+    protected function deleteScormFolder($folderHashedName)
+    {
+        return $this->scormDisk->deleteScorm($folderHashedName);
+    }
+
+    /**
+     * @param string|UploadedFile $file zip.       
+     * @return array
+     * @throws InvalidScormArchiveException
+     */
+    private function generateScorm($file)
+    {
+        $scormData = $this->parseScormArchive($file);
+        /**
+         * Unzip a given ZIP file into the web resources directory.
+         *
+         * @param string $hashName name of the destination directory
+         */
+        $this->scormDisk->unzipper($file, $this->uuid);
+
+        // Update main entry URL to include root path if content is in subdirectory
+        // Use the manifest path we already calculated during parsing
+        if (isset($scormData['manifestPath']) && strpos($scormData['manifestPath'], '/') !== false) {
+            $parentPath = dirname($scormData['manifestPath']);
+            $originalEntryUrl = $scormData['entryUrl'];
+            $scormData['entryUrl'] = $parentPath . '/' . ltrim($scormData['entryUrl'], '/');
+            \Log::info("SCORM content in subdirectory '{$parentPath}'. Entry URL: {$originalEntryUrl} -> {$scormData['entryUrl']}");
+        } else {
+            \Log::info("SCORM content in root directory. Entry URL unchanged: {$scormData['entryUrl']}");
+        }
+
+        return [
+            'identifier' => $scormData['identifier'],
+            'uuid' => $this->uuid,
+            'title' => $scormData['title'], // to follow standard file data format
+            'version' => $scormData['version'],
+            'entryUrl' => $scormData['entryUrl'],
+            'scos' => $scormData['scos'],
+        ];
+    }
+
+    /**
+     * Get SCO list
+     * @param $scormId
+     * @return \Illuminate\Database\Eloquent\Builder[]|\Illuminate\Database\Eloquent\Collection
+     */
+    public function getScos($scormId)
+    {
+        $scos  =   ScormScoModel::with([
+            'scorm'
+        ])->where('scorm_id', $scormId)
+            ->get();
+
+        return $scos;
+    }
+
+    /**
+     * Get sco by uuid
+     * @param $scoUuid
+     * @return null|\Illuminate\Database\Eloquent\Builder|Model
+     */
+    public function getScoByUuid($scoUuid)
+    {
+        $sco    =   ScormScoModel::with(['scorm'])
+            ->where('uuid', $scoUuid)
+            ->firstOrFail();
+
+        return $sco;
+    }
+
+    public function getUserResult($scoId, $userId)
+    {
+        return ScormScoTrackingModel::where('sco_id', $scoId)->where('user_id', $userId)->first();
+    }
+
+    public function createScoTracking($scoUuid, $userId = null, $userName = null)
+    {
+        $sco    =   ScormScoModel::where('uuid', $scoUuid)->firstOrFail();
+
         $version = $sco->scorm->version;
-
         $scoTracking = new ScoTracking();
         $scoTracking->setSco($sco->toArray());
 
         $cmi = null;
-
         switch ($version) {
             case Scorm::SCORM_12:
                 $scoTracking->setLessonStatus('not attempted');
@@ -149,25 +502,28 @@ class ScormManager
                 $scoTracking->setSessionTime(0);
                 $scoTracking->setLessonMode('normal');
                 $scoTracking->setExitMode('');
-                $scoTracking->setIsLocked(!is_null($sco->prerequisites));
 
+                if (is_null($sco->prerequisites)) {
+                    $scoTracking->setIsLocked(false);
+                } else {
+                    $scoTracking->setIsLocked(true);
+                }
                 $cmi = [
-                    'cmi.core.entry'        => $scoTracking->getEntry(),
-                    'cmi.core.student_id'   => $userId,
+                    'cmi.core.entry' => $scoTracking->getEntry(),
+                    'cmi.core.student_id' => $userId,
                     'cmi.core.student_name' => $userName,
                 ];
-                break;
 
+                break;
             case Scorm::SCORM_2004:
                 $scoTracking->setTotalTimeString('PT0S');
                 $scoTracking->setCompletionStatus('unknown');
                 $scoTracking->setLessonStatus('unknown');
                 $scoTracking->setIsLocked(false);
-
                 $cmi = [
-                    'cmi.entry'               => 'ab-initio',
-                    'cmi.learner_id'          => $userId,
-                    'cmi.learner_name'        => $userName,
+                    'cmi.entry' => 'ab-initio',
+                    'cmi.learner_id' =>  $userId,
+                    'cmi.learner_name' => $userName,
                     'cmi.scaled_passing_score' => 0.5,
                 ];
                 break;
@@ -176,795 +532,537 @@ class ScormManager
         $scoTracking->setUserId($userId);
         $scoTracking->setDetails($cmi);
 
-        $stored = ScormScoTrackingModel::firstOrCreate(
-            ['user_id' => $userId, 'sco_id' => $sco->id],
-            [
-                'uuid'               => Str::uuid()->toString(),
-                'progression'        => $scoTracking->getProgression(),
-                'score_raw'          => $scoTracking->getScoreRaw(),
-                'score_min'          => $scoTracking->getScoreMin(),
-                'score_max'          => $scoTracking->getScoreMax(),
-                'score_scaled'       => $scoTracking->getScoreScaled(),
-                'lesson_status'      => $scoTracking->getLessonStatus(),
-                'completion_status'  => $scoTracking->getCompletionStatus(),
-                'session_time'       => $scoTracking->getSessionTime(),
-                'total_time_int'     => $scoTracking->getTotalTimeInt(),
-                'total_time_string'  => $scoTracking->getTotalTimeString(),
-                'entry'              => $scoTracking->getEntry(),
-                'suspend_data'       => $scoTracking->getSuspendData(),
-                'credit'             => $scoTracking->getCredit(),
-                'exit_mode'          => $scoTracking->getExitMode(),
-                'lesson_location'    => $scoTracking->getLessonLocation(),
-                'lesson_mode'        => $scoTracking->getLessonMode(),
-                'is_locked'          => $scoTracking->getIsLocked(),
-                'details'            => $scoTracking->getDetails(),
-                'latest_date'        => $scoTracking->getLatestDate(),
-                'created_at'         => Carbon::now(),
-                'updated_at'         => Carbon::now(),
-            ]
-        );
+        // Create a new tracking model
+        $storeTracking  =   ScormScoTrackingModel::firstOrCreate([
+            'user_id'   =>  $userId,
+            'sco_id'    =>  $sco->id
+        ], [
+            'uuid'  =>   Str::uuid()->toString(),
+            'progression'  =>  $scoTracking->getProgression(),
+            'score_raw'  =>  $scoTracking->getScoreRaw(),
+            'score_min'  =>  $scoTracking->getScoreMin(),
+            'score_max'  =>  $scoTracking->getScoreMax(),
+            'score_scaled'  =>  $scoTracking->getScoreScaled(),
+            'lesson_status'  =>  $scoTracking->getLessonStatus(),
+            'completion_status'  =>  $scoTracking->getCompletionStatus(),
+            'session_time'  =>  $scoTracking->getSessionTime(),
+            'total_time_int'  =>  $scoTracking->getTotalTimeInt(),
+            'total_time_string'  =>  $scoTracking->getTotalTimeString(),
+            'entry'  =>  $scoTracking->getEntry(),
+            'suspend_data'  =>  $scoTracking->getSuspendData(),
+            'credit'  =>  $scoTracking->getCredit(),
+            'exit_mode'  =>  $scoTracking->getExitMode(),
+            'lesson_location'  =>  $scoTracking->getLessonLocation(),
+            'lesson_mode'  =>  $scoTracking->getLessonMode(),
+            'is_locked'  =>  $scoTracking->getIsLocked(),
+            'details'  =>  $scoTracking->getDetails(),
+            'latest_date'  =>  $scoTracking->getLatestDate(),
+            'created_at'  =>  Carbon::now(),
+            'updated_at'  =>  Carbon::now(),
+        ]);
 
-        $this->hydrateTrackingFromModel($scoTracking, $stored);
+        $scoTracking->setUuid($storeTracking->uuid);
+        $scoTracking->setProgression($storeTracking->progression);
+        $scoTracking->setScoreRaw($storeTracking->score_raw);
+        $scoTracking->setScoreMin($storeTracking->score_min);
+        $scoTracking->setScoreMax($storeTracking->score_max);
+        $scoTracking->setScoreScaled($storeTracking->score_scaled);
+        $scoTracking->setLessonStatus($storeTracking->lesson_status);
+        $scoTracking->setCompletionStatus($storeTracking->completion_status);
+        $scoTracking->setSessionTime($storeTracking->session_time);
+        $scoTracking->setTotalTimeInt($storeTracking->total_time_int);
+        $scoTracking->setTotalTimeString($storeTracking->total_time_string);
+        $scoTracking->setEntry($storeTracking->entry);
+        $scoTracking->setSuspendData($storeTracking->suspend_data);
+        $scoTracking->setCredit($storeTracking->credit);
+        $scoTracking->setExitMode($storeTracking->exit_mode);
+        $scoTracking->setLessonLocation($storeTracking->lesson_location);
+        $scoTracking->setLessonMode($storeTracking->lesson_mode);
+        $scoTracking->setIsLocked($storeTracking->is_locked);
+        $scoTracking->setDetails($storeTracking->details);
+        $scoTracking->setLatestDate(Carbon::parse($storeTracking->latest_date));
 
         return $scoTracking;
     }
 
-    public function findScoTrackingId(string $scoUuid, string $scoTrackingUuid): ScormScoTrackingModel
+    public function findScoTrackingId($scoUuid, $scoTrackingUuid)
     {
-        return ScormScoTrackingModel::with('sco')
-            ->whereHas('sco', fn(Builder $q) => $q->where('uuid', $scoUuid))
-            ->where('uuid', $scoTrackingUuid)
+        return ScormScoTrackingModel::with([
+            'sco'
+        ])->whereHas('sco', function (Builder $query) use ($scoUuid) {
+            $query->where('uuid', $scoUuid);
+        })->where('uuid', $scoTrackingUuid)
             ->firstOrFail();
     }
 
-    public function checkUserIsCompletedScorm(int $scormId, int $userId): bool
+    public function checkUserIsCompletedScorm($scormId, $userId)
     {
-        $scos = ScormScoModel::where('scorm_id', $scormId)->get();
 
-        $completedCount = $scos->filter(function ($sco) use ($userId) {
-            $tracking = ScormScoTrackingModel::where('sco_id', $sco->id)
-                ->where('user_id', $userId)
-                ->first();
+        $completedSco    =   [];
+        $scos   =   ScormScoModel::where('scorm_id', $scormId)->get();
 
-            return $tracking && in_array($tracking->lesson_status, ['passed', 'completed'], true);
-        })->count();
+        foreach ($scos as $sco) {
+            $scoTracking    =   ScormScoTrackingModel::where('sco_id', $sco->id)->where('user_id', $userId)->first();
 
-        return $completedCount === $scos->count();
-    }
-
-    public function updateScoTracking(string $scoUuid, int $userId, array $data): ScormScoTrackingModel
-    {
-        $tracking = $this->createScoTracking($scoUuid, $userId);
-        $tracking->setLatestDate(Carbon::now());
-
-        $sco   = $tracking->getSco();
-        $scorm = ScormModel::where('id', $sco['scorm_id'])->firstOrFail();
-
-        match ($scorm->version) {
-            Scorm::SCORM_12   => $this->applyScorm12Data($tracking, $data),
-            Scorm::SCORM_2004 => $this->applyScorm2004Data($tracking, $data),
-        };
-
-        return ScormScoTrackingModel::where('user_id', $tracking->getUserId())
-            ->where('sco_id', $sco['id'])
-            ->firstOrFail()
-            ->tap(function (ScormScoTrackingModel $model) use ($tracking) {
-                $model->progression       = $tracking->getProgression();
-                $model->score_raw         = $tracking->getScoreRaw();
-                $model->score_min         = $tracking->getScoreMin();
-                $model->score_max         = $tracking->getScoreMax();
-                $model->score_scaled      = $tracking->getScoreScaled();
-                $model->lesson_status     = $tracking->getLessonStatus();
-                $model->completion_status = $tracking->getCompletionStatus();
-                $model->session_time      = $tracking->getSessionTime();
-                $model->total_time_int    = $tracking->getTotalTimeInt();
-                $model->total_time_string = $tracking->getTotalTimeString();
-                $model->entry             = $tracking->getEntry();
-                $model->suspend_data      = $tracking->getSuspendData();
-                $model->exit_mode         = $tracking->getExitMode();
-                $model->credit            = $tracking->getCredit();
-                $model->lesson_location   = $tracking->getLessonLocation();
-                $model->lesson_mode       = $tracking->getLessonMode();
-                $model->is_locked         = $tracking->getIsLocked();
-                $model->details           = $tracking->getDetails();
-                $model->latest_date       = $tracking->getLatestDate();
-                $model->save();
-            });
-    }
-
-    public function resetUserData(int $scormId, int $userId): void
-    {
-        ScormScoModel::where('scorm_id', $scormId)
-            ->get()
-            ->each(function (ScormScoModel $sco) use ($userId) {
-                ScormScoTrackingModel::where('sco_id', $sco->id)
-                    ->where('user_id', $userId)
-                    ->delete();
-            });
-    }
-
-    // =========================================================================
-    // Delete
-    // =========================================================================
-
-    public function deleteScorm(ScormModel $model): void
-    {
-        if (!$model) {
-            return;
+            if ($scoTracking && ($scoTracking->lesson_status == 'passed' || $scoTracking->lesson_status == 'completed')) {
+                $completedSco[] =   true;
+            }
         }
 
-        $this->deleteScormData($model);
-        $model->delete();
-    }
-
-    // =========================================================================
-    // Private — persistence
-    // =========================================================================
-
-    /**
-     * Orchestrates validation → parsing → extraction → DB persistence.
-     *
-     * @param  string|UploadedFile  $file
-     */
-    private function saveScorm($file, string $filename, ?string $uuid = null): ScormModel
-    {
-        $this->validatePackage($file);
-
-        $scormData = $this->generateScorm($file);
-
-        if (empty($scormData) || !is_array($scormData)) {
-            $this->onError('invalid_scorm_data');
-        }
-
-        // An explicit UUID overrides the one generated at upload-entry.
-        if (!empty($uuid)) {
-            $this->uuid = $uuid;
-        }
-
-        $scorm = ScormModel::where('uuid', $this->uuid)->first();
-
-        if ($scorm === null) {
-            $scorm = new ScormModel();
+        if (count($completedSco) == $scos->count()) {
+            return true;
         } else {
-            $this->deleteScormData($scorm);
-        }
-
-        $scorm->uuid         = $this->uuid;
-        $scorm->title        = $scormData['title'];
-        $scorm->version      = $scormData['version'];
-        $scorm->entry_url    = $scormData['entryUrl'];
-        $scorm->identifier   = $scormData['identifier'];
-        $scorm->origin_file  = $filename;
-        $scorm->metadata     = [
-            'package_size' => $this->getFileSize($file),
-            'created_at'   => $scormData['created_at'] ?? null,
-            'created_by'   => $scormData['created_by'] ?? null,
-        ];
-        $scorm->save();
-
-        if (!empty($scormData['scos'])) {
-            Log::info('ScormManager::saveScorm — saving ' . count($scormData['scos']) . ' SCO(s)');
-            foreach ($scormData['scos'] as $scoData) {
-                $this->saveScormScosRecursively($scorm->id, $scoData);
-            }
-        } else {
-            Log::warning('ScormManager::saveScorm — no SCOs found in parsed data');
-        }
-
-        return $scorm;
-    }
-
-    private function saveScormScosRecursively(int $scormId, Sco $scoData, ?int $parentId = null): ScormScoModel
-    {
-        $sco = $this->persistSco($scormId, $scoData, $parentId);
-
-        if (!empty($scoData->scoChildren) && is_array($scoData->scoChildren)) {
-            foreach ($scoData->scoChildren as $child) {
-                $this->saveScormScosRecursively($scormId, $child, $sco->id);
-            }
-        }
-
-        return $sco;
-    }
-
-    private function persistSco(int $scormId, Sco $scoData, ?int $parentId = null): ScormScoModel
-    {
-        $sco = new ScormScoModel([
-            'scorm_id'            => $scormId,
-            'uuid'                => $scoData->uuid,
-            'sco_parent_id'       => $parentId,
-            'entry_url'           => $scoData->entryUrl,
-            'identifier'          => $scoData->identifier,
-            'title'               => $scoData->title,
-            'visible'             => $scoData->visible,
-            'sco_parameters'      => $scoData->parameters,
-            'launch_data'         => $scoData->launchData,
-            'max_time_allowed'    => $scoData->maxTimeAllowed,
-            'time_limit_action'   => $scoData->timeLimitAction,
-            'block'               => $scoData->block,
-            'score_int'           => $scoData->scoreToPassInt,
-            'score_decimal'       => $scoData->scoreToPassDecimal,
-            'completion_threshold' => $scoData->completionThreshold,
-            'prerequisites'       => $scoData->prerequisites,
-        ]);
-
-        $sco->save();
-
-        Log::info('ScormManager::persistSco — saved SCO: ' . $sco->identifier);
-
-        return $sco;
-    }
-
-    private function deleteScormData(ScormModel $model): void
-    {
-        $model->scos()->each(function (ScormScoModel $sco) {
-            $sco->scoTrackings()->delete();
-        });
-
-        $model->scos()->delete();
-        $this->scormDisk->deleteScorm($model->uuid);
-    }
-
-    // =========================================================================
-    // Private — SCORM package parsing
-    // =========================================================================
-
-    /**
-     * Open the zip and confirm imsmanifest.xml is present.
-     *
-     * @param  string|UploadedFile  $file
-     */
-    private function validatePackage($file): void
-    {
-        $zip            = new ZipArchive();
-        $manifestResult = null;
-
-        try {
-            if ($zip->open($this->resolveFilePath($file)) !== true) {
-                $this->onError('invalid_scorm_archive_message');
-            }
-            $manifestResult = $this->findManifestInZip($zip);
-        } finally {
-            $this->closeManifestStream($manifestResult);
-            $zip->close();
-        }
-
-        if (!$manifestResult['found']) {
-            Log::error('ScormManager::validatePackage — imsmanifest.xml not found');
-            $this->onError('invalid_scorm_archive_message');
-        }
-
-        Log::info('ScormManager::validatePackage — manifest at: ' . $manifestResult['path']);
-    }
-
-    /**
-     * Parse and extract SCORM archive content.
-     *
-     * @param  string|UploadedFile  $file
-     */
-    private function generateScorm($file): array
-    {
-        $scormData = $this->parseScormArchive($file);
-
-        $this->scormDisk->unzipper($this->resolveFilePath($file), $this->uuid);
-
-        // If the manifest lived inside a subdirectory, prepend that prefix to
-        // all entry URLs so the browser can resolve assets correctly.
-        if (isset($scormData['manifestPath']) && str_contains($scormData['manifestPath'], '/')) {
-            $prefix = dirname($scormData['manifestPath']);
-            $original = $scormData['entryUrl'];
-            $scormData['entryUrl'] = $prefix . '/' . ltrim($scormData['entryUrl'], '/');
-            Log::info("ScormManager::generateScorm — entry URL adjusted: {$original} → {$scormData['entryUrl']}");
-        }
-
-        return [
-            'identifier' => $scormData['identifier'],
-            'uuid'       => $this->uuid,
-            'title'      => $scormData['title'],
-            'version'    => $scormData['version'],
-            'entryUrl'   => $scormData['entryUrl'],
-            'scos'       => $scormData['scos'],
-            'created_at' => $scormData['created_at'] ?? null,
-            'created_by' => $scormData['created_by'] ?? null,
-        ];
-    }
-
-    /**
-     * Read imsmanifest.xml from the zip and parse all relevant SCORM data.
-     *
-     * @param  string|UploadedFile  $file
-     */
-    private function parseScormArchive($file): array
-    {
-        $zip            = new ZipArchive();
-        $manifestResult = null;
-        $contents       = '';
-
-        try {
-            if ($zip->open($this->resolveFilePath($file)) !== true) {
-                $this->onError('cannot_load_imsmanifest_message');
-            }
-
-            $manifestResult = $this->findManifestInZip($zip);
-
-            if (!$manifestResult['found']) {
-                $this->onError('cannot_load_imsmanifest_message');
-            }
-
-            // Read the manifest stream in 8 KB chunks.
-            while (!feof($manifestResult['stream'])) {
-                $contents .= fread($manifestResult['stream'], 8192);
-            }
-        } finally {
-            $this->closeManifestStream($manifestResult);
-            $zip->close();
-        }
-
-        $dom = new DOMDocument();
-        $contents = $this->fixXmlEntities($contents);
-
-        if (!$dom->loadXML($contents)) {
-            $this->onError('cannot_load_imsmanifest_message');
-        }
-
-        return $this->extractManifestData($dom, $manifestResult['path']);
-    }
-
-    /**
-     * Pull all required fields from the parsed DOMDocument.
-     */
-    private function extractManifestData(DOMDocument $dom, string $manifestPath): array
-    {
-        $data       = [];
-        $manifest   = $dom->getElementsByTagName('manifest')->item(0);
-        $identifier = $manifest?->attributes->getNamedItem('identifier');
-
-        if ($identifier === null) {
-            $this->onError('invalid_scorm_manifest_identifier');
-        }
-
-        $data['identifier'] = $identifier->nodeValue;
-
-        $titles = $dom->getElementsByTagName('title');
-        $data['title'] = $titles->length > 0
-            ? Str::of($titles->item(0)->textContent)->trim('/n')->trim()->toString()
-            : '';
-
-        $schemaVersion = $dom->getElementsByTagName('schemaversion');
-
-        if ($schemaVersion->length === 0) {
-            $this->onError('invalid_scorm_version_message');
-        }
-
-        $data['version'] = match ($schemaVersion->item(0)->textContent) {
-            '1.2'             => Scorm::SCORM_12,
-            'CAM 1.3',
-            '2004 3rd Edition',
-            '2004 4th Edition' => Scorm::SCORM_2004,
-            default           => $this->onError('invalid_scorm_version_message'),
-        };
-
-        $scos = $this->scormLib->parseOrganizationsNode($dom);
-
-        if (empty($scos)) {
-            Log::error('ScormManager::extractManifestData — no SCOs found');
-            $this->onError('no_sco_in_scorm_archive_message');
-        }
-
-        $data['entryUrl']     = $scos[0]->entryUrl ?? $scos[0]->scoChildren[0]->entryUrl;
-        $data['scos']         = $scos;
-        $data['manifestPath'] = $manifestPath;
-        $data['created_at']   = $this->extractCreationDate($dom);
-        $data['created_by']   = $this->extractCreator($dom);
-
-        Log::info('ScormManager::extractManifestData — ' . count($scos) . ' SCO(s), entryUrl: ' . $data['entryUrl']);
-
-        return $data;
-    }
-
-    // =========================================================================
-    // Private — tracking data application
-    // =========================================================================
-
-    private function applyScorm12Data(ScoTracking $tracking, array $data): void
-    {
-        $tracking->setDetails($data);
-
-        if (!empty($data['cmi.suspend_data'])) {
-            $tracking->setSuspendData($data['cmi.suspend_data']);
-        }
-
-        $scoreRaw    = isset($data['cmi.core.score.raw'])  ? (int) $data['cmi.core.score.raw']  : null;
-        $scoreMin    = isset($data['cmi.core.score.min'])  ? (int) $data['cmi.core.score.min']  : null;
-        $scoreMax    = isset($data['cmi.core.score.max'])  ? (int) $data['cmi.core.score.max']  : null;
-        $lessonStatus  = $data['cmi.core.lesson_status']  ?? 'unknown';
-        $sessionTime   = $data['cmi.core.session_time']   ?? null;
-        $entry         = $data['cmi.core.entry']          ?? null;
-        $exit          = $data['cmi.core.exit']           ?? null;
-        $lessonLocation = $data['cmi.core.lesson_location'] ?? null;
-        $totalTime     = $data['cmi.core.total_time']     ?? 0;
-
-        $tracking->setEntry($entry);
-        $tracking->setExitMode($exit);
-        $tracking->setLessonLocation($lessonLocation);
-        $tracking->setSessionTime($this->convertTimeInHundredth($sessionTime));
-        $tracking->setTotalTime($this->convertTimeInHundredth($totalTime), Scorm::SCORM_12);
-        $tracking->setLessonStatus($lessonStatus);
-
-        // Keep best score
-        $bestScore = $tracking->getScoreRaw();
-        if (empty($bestScore) || (!is_null($scoreRaw) && $scoreRaw > (int) $bestScore)) {
-            $tracking->setScoreRaw($scoreRaw);
-            $tracking->setScoreMin($scoreMin);
-            $tracking->setScoreMax($scoreMax);
-        }
-
-        $progression = !empty($scoreRaw) ? (float) $scoreRaw : 0.0;
-        if ($progression === 0.0 && in_array($lessonStatus, ['completed', 'passed'], true)) {
-            $progression = 100.0;
-        }
-        if ($progression > $tracking->getProgression()) {
-            $tracking->setProgression($progression);
-        }
-    }
-
-    private function applyScorm2004Data(ScoTracking $tracking, array $data): void
-    {
-        $tracking->setDetails($data);
-
-        if (!empty($data['cmi.suspend_data'])) {
-            $tracking->setSuspendData($data['cmi.suspend_data']);
-        }
-
-        $completionStatus = $data['cmi.completion_status'] ?? 'unknown';
-        $successStatus    = $data['cmi.success_status']    ?? 'unknown';
-        $scoreRaw         = isset($data['cmi.score.raw'])    ? (int)   $data['cmi.score.raw']    : null;
-        $scoreMin         = isset($data['cmi.score.min'])    ? (int)   $data['cmi.score.min']    : null;
-        $scoreMax         = isset($data['cmi.score.max'])    ? (int)   $data['cmi.score.max']    : null;
-        $scoreScaled      = isset($data['cmi.score.scaled']) ? (float) $data['cmi.score.scaled'] : null;
-        $progression      = isset($data['cmi.progress_measure']) ? (float) $data['cmi.progress_measure'] : 0.0;
-
-        // Compute cumulative total time
-        $sessionTimeStr = isset($data['cmi.session_time'])
-            ? $this->formatSessionTime($data['cmi.session_time'])
-            : 'PT0S';
-
-        try {
-            $totalTime   = new DateInterval($tracking->getTotalTimeString() ?: 'PT0S');
-            $sessionTime = new DateInterval($sessionTimeStr);
-        } catch (Exception) {
-            $totalTime   = new DateInterval('PT0S');
-            $sessionTime = new DateInterval('PT0S');
-        }
-
-        $base = new DateTime('@0');
-        $base->add($totalTime)->add($sessionTime);
-        $totalTimeInterval = $this->retrieveIntervalFromSeconds($base->getTimestamp());
-
-        $data['cmi.total_time'] = $totalTimeInterval;
-        $tracking->setTotalTimeString($totalTimeInterval);
-
-        // Keep best score
-        $bestScore = $tracking->getScoreRaw();
-        if (empty($bestScore) || (!is_null($scoreRaw) && $scoreRaw > (int) $bestScore)) {
-            $tracking->setScoreRaw($scoreRaw);
-            $tracking->setScoreMin($scoreMin);
-            $tracking->setScoreMax($scoreMax);
-            $tracking->setScoreScaled($scoreScaled);
-        }
-
-        // Merge completion + success into a single lesson status
-        $lessonStatus = in_array($successStatus, ['passed', 'failed'], true)
-            ? $successStatus
-            : $completionStatus;
-
-        $tracking->setLessonStatus($lessonStatus);
-
-        $currentPriority  = self::STATUS_PRIORITY[$completionStatus]            ?? 0;
-        $existingPriority = self::STATUS_PRIORITY[$tracking->getCompletionStatus()] ?? 0;
-
-        if (empty($tracking->getCompletionStatus()) || $currentPriority > $existingPriority) {
-            $tracking->setCompletionStatus($completionStatus);
-        }
-
-        if ($progression === 0.0 && in_array($lessonStatus, ['completed', 'passed'], true)) {
-            $progression = 100.0;
-        }
-        if ($progression > $tracking->getProgression()) {
-            $tracking->setProgression($progression);
-        }
-    }
-
-    // =========================================================================
-    // Private — ZIP helpers
-    // =========================================================================
-
-    /**
-     * Find imsmanifest.xml inside a ZipArchive, checking the root first,
-     * then subdirectories.
-     *
-     * @return array{found: bool, path: string, stream: resource|null}
-     */
-    private function findManifestInZip(ZipArchive $zip): array
-    {
-        // Root check
-        $stream = $zip->getStream('imsmanifest.xml');
-        if ($stream !== false) {
-            Log::info('ScormManager::findManifestInZip — found at root');
-            return ['found' => true, 'path' => 'imsmanifest.xml', 'stream' => $stream];
-        }
-
-        // Subdirectory search
-        for ($i = 0; $i < $zip->numFiles; ++$i) {
-            $name = $zip->getNameIndex($i);
-            if (strtolower(basename($name)) === 'imsmanifest.xml') {
-                $stream = $zip->getStream($name);
-                if ($stream !== false) {
-                    Log::info('ScormManager::findManifestInZip — found at: ' . $name);
-                    return ['found' => true, 'path' => $name, 'stream' => $stream];
-                }
-            }
-        }
-
-        return ['found' => false, 'path' => '', 'stream' => null];
-    }
-
-    /** Close the manifest stream if it is still open. */
-    private function closeManifestStream(?array $manifestResult): void
-    {
-        if (
-            $manifestResult !== null
-            && isset($manifestResult['stream'])
-            && is_resource($manifestResult['stream'])
-        ) {
-            fclose($manifestResult['stream']);
-        }
-    }
-
-    // =========================================================================
-    // Private — manifest metadata extraction
-    // =========================================================================
-
-    /**
-     * Extract creation date from SCORM manifest LOM metadata.
-     * Returns an ISO-8601 string or null.
-     */
-    private function extractCreationDate(DOMDocument $dom): ?string
-    {
-        try {
-            $xpath = $this->buildXPath($dom);
-
-            foreach (
-                [
-                    '//lom:dateTime[ancestor::lom:contribute[lom:role/lom:value[text()="creator" or text()="author"]]]',
-                    '//lom:dateTime[ancestor::lom:contribute]',
-                    '//lom:dateTime',
-                ] as $query
-            ) {
-                $nodes = $this->safeXPathQuery($xpath, $query);
-                if ($nodes && $nodes->length > 0) {
-                    return $this->formatDate($nodes->item(0)->textContent);
-                }
-            }
-        } catch (Exception $e) {
-            Log::warning('ScormManager::extractCreationDate — ' . $e->getMessage());
-        }
-
-        return null;
-    }
-
-    /**
-     * Extract the creator/author from SCORM manifest LOM metadata.
-     */
-    private function extractCreator(DOMDocument $dom): ?string
-    {
-        try {
-            $xpath = $this->buildXPath($dom);
-
-            foreach (
-                [
-                    '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="creator"]]]',
-                    '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="author"]]]',
-                    '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="publisher"]]]',
-                    '//lom:entity[ancestor::lom:contribute]',
-                    '//lom:entity',
-                ] as $query
-            ) {
-                $nodes = $this->safeXPathQuery($xpath, $query);
-                if ($nodes && $nodes->length > 0) {
-                    return trim($nodes->item(0)->textContent);
-                }
-            }
-        } catch (Exception $e) {
-            Log::warning('ScormManager::extractCreator — ' . $e->getMessage());
-        }
-
-        return null;
-    }
-
-    private function buildXPath(DOMDocument $dom): DOMXPath
-    {
-        $xpath = new DOMXPath($dom);
-        $xpath->registerNamespace('lom',    'http://ltsc.ieee.org/xsd/LOM');
-        $xpath->registerNamespace('adlcp',  'http://www.adlnet.org/xsd/adlcp_v1p3');
-        $xpath->registerNamespace('adlseq', 'http://www.adlnet.org/xsd/adlseq_v1p3');
-        $xpath->registerNamespace('adlnav', 'http://www.adlnet.org/xsd/adlnav_v1p3');
-        return $xpath;
-    }
-
-    private function safeXPathQuery(DOMXPath $xpath, string $query): \DOMNodeList|false
-    {
-        try {
-            return $xpath->query($query);
-        } catch (Exception $e) {
-            Log::warning('ScormManager::safeXPathQuery — "' . $query . '": ' . $e->getMessage());
             return false;
         }
     }
 
-    private function formatDate(string $dateString): ?string
+    public function updateScoTracking($scoUuid, $userId, $data)
     {
-        if (empty($dateString)) {
-            return null;
+        $tracking = $this->createScoTracking($scoUuid, $userId);
+        $tracking->setLatestDate(Carbon::now());
+        $sco    =   $tracking->getSco();
+        $scorm  =   ScormModel::where('id', $sco['scorm_id'])->firstOrFail();
+
+        $statusPriority = [
+            'unknown' => 0,
+            'not attempted' => 1,
+            'browsed' => 2,
+            'incomplete' => 3,
+            'completed' => 4,
+            'failed' => 5,
+            'passed' => 6,
+        ];
+
+        switch ($scorm->version) {
+            case Scorm::SCORM_12:
+                if (isset($data['cmi.suspend_data']) && !empty($data['cmi.suspend_data'])) {
+                    $tracking->setSuspendData($data['cmi.suspend_data']);
+                }
+
+                $scoreRaw = isset($data['cmi.core.score.raw']) ? intval($data['cmi.core.score.raw']) : null;
+                $scoreMin = isset($data['cmi.core.score.min']) ? intval($data['cmi.core.score.min']) : null;
+                $scoreMax = isset($data['cmi.core.score.max']) ? intval($data['cmi.core.score.max']) : null;
+                $lessonStatus = isset($data['cmi.core.lesson_status']) ? $data['cmi.core.lesson_status'] : 'unknown';
+                $sessionTime = isset($data['cmi.core.session_time']) ? $data['cmi.core.session_time'] : null;
+                $sessionTimeInHundredth = $this->convertTimeInHundredth($sessionTime);
+                $progression = !empty($scoreRaw) ? floatval($scoreRaw) : 0;
+                $entry  =   isset($data['cmi.core.entry']) ? $data['cmi.core.entry'] : null;
+                $exit  =   isset($data['cmi.core.exit']) ? $data['cmi.core.exit'] : null;
+                $lessonLocation =   isset($data['cmi.core.lesson_location']) ? $data['cmi.core.lesson_location'] : null;
+                $totalTime  =   isset($data['cmi.core.total_time']) ? $data['cmi.core.total_time'] : 0;
+
+                $tracking->setDetails($data);
+                $tracking->setEntry($entry);
+                $tracking->setExitMode($exit);
+                $tracking->setLessonLocation($lessonLocation);
+                $tracking->setSessionTime($sessionTimeInHundredth);
+
+                // Compute total time
+                $totalTimeInHundredth = $this->convertTimeInHundredth($totalTime);
+                $tracking->setTotalTime($totalTimeInHundredth, Scorm::SCORM_12);
+
+                $bestScore = $tracking->getScoreRaw();
+
+                // Update best score if the current score is better than the previous best score
+
+                if (empty($bestScore) || (!is_null($scoreRaw) && (int)$scoreRaw > (int)$bestScore)) {
+                    $tracking->setScoreRaw($scoreRaw);
+                    $tracking->setScoreMin($scoreMin);
+                    $tracking->setScoreMax($scoreMax);
+                }
+
+                $tracking->setLessonStatus($lessonStatus);
+                $bestStatus = $lessonStatus;
+
+                if (empty($progression) && ('completed' === $bestStatus || 'passed' === $bestStatus)) {
+                    $progression = 100;
+                }
+
+                if ($progression > $tracking->getProgression()) {
+                    $tracking->setProgression($progression);
+                }
+
+                break;
+
+            case Scorm::SCORM_2004:
+                $tracking->setDetails($data);
+
+                if (isset($data['cmi.suspend_data']) && !empty($data['cmi.suspend_data'])) {
+                    $tracking->setSuspendData($data['cmi.suspend_data']);
+                }
+
+                $dataSessionTime = isset($data['cmi.session_time']) ?
+                    $this->formatSessionTime($data['cmi.session_time']) :
+                    'PT0S';
+                $completionStatus = isset($data['cmi.completion_status']) ? $data['cmi.completion_status'] : 'unknown';
+                $successStatus = isset($data['cmi.success_status']) ? $data['cmi.success_status'] : 'unknown';
+                $scoreRaw = isset($data['cmi.score.raw']) ? intval($data['cmi.score.raw']) : null;
+                $scoreMin = isset($data['cmi.score.min']) ? intval($data['cmi.score.min']) : null;
+                $scoreMax = isset($data['cmi.score.max']) ? intval($data['cmi.score.max']) : null;
+                $scoreScaled = isset($data['cmi.score.scaled']) ? floatval($data['cmi.score.scaled']) : null;
+                $progression = isset($data['cmi.progress_measure']) ? floatval($data['cmi.progress_measure']) : 0;
+                $bestScore = $tracking->getScoreRaw();
+
+                // Computes total time
+                $totalTime = new \DateInterval($tracking->getTotalTimeString());
+
+                try {
+                    $sessionTime = new \DateInterval($dataSessionTime);
+                } catch (\Exception $e) {
+                    $sessionTime = new \DateInterval('PT0S');
+                }
+                $computedTime = new \DateTime();
+                $computedTime->setTimestamp(0);
+                $computedTime->add($totalTime);
+                $computedTime->add($sessionTime);
+                $computedTimeInSecond = $computedTime->getTimestamp();
+                $totalTimeInterval = $this->retrieveIntervalFromSeconds($computedTimeInSecond);
+                $data['cmi.total_time'] = $totalTimeInterval;
+                $tracking->setTotalTimeString($totalTimeInterval);
+
+                // Update best score if the current score is better than the previous best score
+                if (empty($bestScore) || (!is_null($scoreRaw) && (int)$scoreRaw > (int)$bestScore)) {
+                    $tracking->setScoreRaw($scoreRaw);
+                    $tracking->setScoreMin($scoreMin);
+                    $tracking->setScoreMax($scoreMax);
+                    $tracking->setScoreScaled($scoreScaled);
+                }
+
+                // Update best success status and completion status
+                $lessonStatus = $completionStatus;
+                if (in_array($successStatus, ['passed', 'failed'])) {
+                    $lessonStatus = $successStatus;
+                }
+
+                $tracking->setLessonStatus($lessonStatus);
+                $bestStatus = $lessonStatus;
+
+                if (
+                    empty($tracking->getCompletionStatus())
+                    || ($completionStatus !== $tracking->getCompletionStatus() && $statusPriority[$completionStatus] > $statusPriority[$tracking->getCompletionStatus()])
+                ) {
+                    // This is no longer needed as completionStatus and successStatus are merged together
+                    // I keep it for now for possible retro compatibility
+                    $tracking->setCompletionStatus($completionStatus);
+                }
+
+                if (empty($progression) && ('completed' === $bestStatus || 'passed' === $bestStatus)) {
+                    $progression = 100;
+                }
+
+                if ($progression > $tracking->getProgression()) {
+                    $tracking->setProgression($progression);
+                }
+
+                break;
         }
-        try {
-            return (new DateTime($dateString))->format('c');
-        } catch (Exception) {
-            return trim($dateString);
+
+        $updateResult   =   ScormScoTrackingModel::where('user_id', $tracking->getUserId())
+            ->where('sco_id', $sco['id'])
+            ->firstOrFail();
+
+        $updateResult->progression  =   $tracking->getProgression();
+        $updateResult->score_raw    =   $tracking->getScoreRaw();
+        $updateResult->score_min    =   $tracking->getScoreMin();
+        $updateResult->score_max    =   $tracking->getScoreMax();
+        $updateResult->score_scaled    =   $tracking->getScoreScaled();
+        $updateResult->lesson_status    =   $tracking->getLessonStatus();
+        $updateResult->completion_status    =   $tracking->getCompletionStatus();
+        $updateResult->session_time    =   $tracking->getSessionTime();
+        $updateResult->total_time_int    =   $tracking->getTotalTimeInt();
+        $updateResult->total_time_string    =   $tracking->getTotalTimeString();
+        $updateResult->entry    =   $tracking->getEntry();
+        $updateResult->suspend_data    =   $tracking->getSuspendData();
+        $updateResult->exit_mode    =   $tracking->getExitMode();
+        $updateResult->credit    =   $tracking->getCredit();
+        $updateResult->lesson_location    =   $tracking->getLessonLocation();
+        $updateResult->lesson_mode    =   $tracking->getLessonMode();
+        $updateResult->is_locked    =   $tracking->getIsLocked();
+        $updateResult->details    =   $tracking->getDetails();
+        $updateResult->latest_date    =   $tracking->getLatestDate();
+
+        $updateResult->save();
+
+        return $updateResult;
+    }
+
+    public function resetUserData($scormId, $userId)
+    {
+        $scos   =   ScormScoModel::where('scorm_id', $scormId)->get();
+
+        foreach ($scos as $sco) {
+            $scoTracking    =   ScormScoTrackingModel::where('sco_id', $sco->id)->where('user_id', $userId)->delete();
         }
     }
 
-    // =========================================================================
-    // Private — XML / time utilities
-    // =========================================================================
-
-    /**
-     * Escape unescaped ampersands in XML while preserving CDATA sections.
-     */
-    private function fixXmlEntities(string $xml): string
+    private function convertTimeInHundredth($time)
     {
-        $cdata = [];
+        if ($time != null) {
+            $timeInArray = explode(':', $time);
+            $timeInArraySec = explode('.', $timeInArray[2]);
+            $timeInHundredth = 0;
 
-        $xml = preg_replace_callback(
-            '/<!\[CDATA\[(.*?)\]\]>/s',
-            function (array $m) use (&$cdata): string {
-                $key         = '__CDATA_' . count($cdata) . '__';
-                $cdata[$key] = $m[0];
-                return $key;
-            },
-            $xml
-        );
+            if (isset($timeInArraySec[1])) {
+                if (1 === strlen($timeInArraySec[1])) {
+                    $timeInArraySec[1] .= '0';
+                }
+                $timeInHundredth = intval($timeInArraySec[1]);
+            }
+            $timeInHundredth += intval($timeInArraySec[0]) * 100;
+            $timeInHundredth += intval($timeInArray[1]) * 6000;
+            $timeInHundredth += intval($timeInArray[0]) * 360000;
 
-        // Escape bare & that are not already part of a valid entity reference.
-        $xml = preg_replace('/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);)/', '&amp;', $xml);
-
-        return str_replace(array_keys($cdata), $cdata, $xml);
-    }
-
-    /**
-     * Convert HH:MM:SS.ss time string into hundredths of a second.
-     */
-    private function convertTimeInHundredth(?string $time): int
-    {
-        if (empty($time)) {
+            return $timeInHundredth;
+        } else {
             return 0;
         }
-
-        [$h, $m, $secFull] = explode(':', $time);
-        [$sec, $frac]      = array_pad(explode('.', $secFull), 2, '0');
-
-        // Normalise fraction to two digits
-        $frac = str_pad(substr($frac, 0, 2), 2, '0');
-
-        return (int) $frac
-            + (int) $sec   * 100
-            + (int) $m     * 6_000
-            + (int) $h     * 360_000;
-    }
-
-    /** Convert a total number of seconds into a P…DT…H…M…S DateInterval string. */
-    private function retrieveIntervalFromSeconds(int $seconds): string
-    {
-        if ($seconds === 0) {
-            return 'PT0S';
-        }
-
-        $d = intdiv($seconds, 86_400);
-        $seconds %= 86_400;
-        $h = intdiv($seconds,  3_600);
-        $seconds %=  3_600;
-        $m = intdiv($seconds,     60);
-        $s = $seconds % 60;
-
-        return "P{$d}DT{$h}H{$m}M{$s}S";
     }
 
     /**
-     * Validate and normalise a SCORM 2004 session-time ISO-8601 string.
-     */
-    private function formatSessionTime(string $sessionTime): string
-    {
-        if ($sessionTime === 'PT') {
-            return 'PT0S';
-        }
-
-        $general = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?([0-9]+S)?$/';
-        $decimal = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?[0-9]+\.[0-9]{1,2}S$/';
-
-        if (preg_match($general, $sessionTime)) {
-            return $sessionTime;
-        }
-
-        if (preg_match($decimal, $sessionTime)) {
-            return (string) preg_replace('/\.[0-9]+S$/', 'S', $sessionTime);
-        }
-
-        return 'PT0S';
-    }
-
-    // =========================================================================
-    // Private — misc helpers
-    // =========================================================================
-
-    /**
-     * Return the real filesystem path whether $file is an UploadedFile or a
-     * plain string path (the OS tmp path from ScormDisk::readScormArchive).
+     * Converts a time in seconds to a DateInterval string.
      *
-     * @param  string|UploadedFile  $file
-     */
-    private function resolveFilePath($file): string
-    {
-        return $file instanceof UploadedFile ? $file->getRealPath() : $file;
-    }
-
-    /**
-     * Copy all persisted fields from a ScormScoTrackingModel back into the
-     * ScoTracking entity so callers always work with a fully hydrated object.
-     */
-    private function hydrateTrackingFromModel(ScoTracking $tracking, ScormScoTrackingModel $model): void
-    {
-        $tracking->setUuid($model->uuid);
-        $tracking->setProgression($model->progression);
-        $tracking->setScoreRaw($model->score_raw);
-        $tracking->setScoreMin($model->score_min);
-        $tracking->setScoreMax($model->score_max);
-        $tracking->setScoreScaled($model->score_scaled);
-        $tracking->setLessonStatus($model->lesson_status);
-        $tracking->setCompletionStatus($model->completion_status);
-        $tracking->setSessionTime($model->session_time);
-        $tracking->setTotalTimeInt($model->total_time_int);
-        $tracking->setTotalTimeString($model->total_time_string);
-        $tracking->setEntry($model->entry);
-        $tracking->setSuspendData($model->suspend_data);
-        $tracking->setCredit($model->credit);
-        $tracking->setExitMode($model->exit_mode);
-        $tracking->setLessonLocation($model->lesson_location);
-        $tracking->setLessonMode($model->lesson_mode);
-        $tracking->setIsLocked($model->is_locked);
-        $tracking->setDetails($model->details);
-        $tracking->setLatestDate(Carbon::parse($model->latest_date));
-    }
-
-    /**
-     * Get file size in bytes.
+     * @param int $seconds
      *
-     * @param  string|UploadedFile  $file
+     * @return string
      */
-    private function getFileSize($file): int
+    private function retrieveIntervalFromSeconds($seconds)
+    {
+        $result = '';
+        $remainingTime = (int) $seconds;
+
+        if (empty($remainingTime)) {
+            $result .= 'PT0S';
+        } else {
+            $nbDays = (int) ($remainingTime / 86400);
+            $remainingTime %= 86400;
+            $nbHours = (int) ($remainingTime / 3600);
+            $remainingTime %= 3600;
+            $nbMinutes = (int) ($remainingTime / 60);
+            $nbSeconds = $remainingTime % 60;
+            $result .= 'P' . $nbDays . 'DT' . $nbHours . 'H' . $nbMinutes . 'M' . $nbSeconds . 'S';
+        }
+
+        return $result;
+    }
+
+    private function formatSessionTime($sessionTime)
+    {
+        $formattedValue = 'PT0S';
+        $generalPattern = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?([0-9]+S)?$/';
+        $decimalPattern = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?[0-9]+\.[0-9]{1,2}S$/';
+
+        if ('PT' !== $sessionTime) {
+            if (preg_match($generalPattern, $sessionTime)) {
+                $formattedValue = $sessionTime;
+            } elseif (preg_match($decimalPattern, $sessionTime)) {
+                $formattedValue = preg_replace(['/\.[0-9]+S$/'], ['S'], $sessionTime);
+            }
+        }
+
+        return $formattedValue;
+    }
+
+    /**
+     * Get file size in bytes
+     * 
+     * @param string|UploadedFile $file
+     * @return int
+     */
+    private function getFileSize($file)
     {
         if ($file instanceof UploadedFile) {
             return $file->getSize();
         }
 
-        return is_string($file) && file_exists($file) ? (int) filesize($file) : 0;
+        if (is_string($file) && file_exists($file)) {
+            return filesize($file);
+        }
+
+        return 0;
     }
 
     /**
-     * Clean up any partially-written files and throw.
-     *
-     * @return never
+     * Extract creation date from SCORM manifest metadata following SCORM standards
      */
-    private function onError(string $msg): never
+    private function extractCreationDate(DOMDocument $dom)
+    {
+        try {
+            $xpath = new \DOMXPath($dom);
+
+            // Register common SCORM namespaces with error handling
+            $this->registerScormNamespaces($xpath);
+
+            // SCORM 2004: Look for lom:lom/lom:lifeCycle/lom:contribute/lom:date/lom:dateTime
+            // Priority 1: Creator/Author contribution date
+            $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime[ancestor::lom:contribute[lom:role/lom:value[text()="creator" or text()="author"]]]');
+            if ($dateNodes && $dateNodes->length > 0) {
+                return $this->formatDate($dateNodes->item(0)->textContent);
+            }
+
+            // Priority 2: Any contribution date
+            $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime[ancestor::lom:contribute]');
+            if ($dateNodes && $dateNodes->length > 0) {
+                return $this->formatDate($dateNodes->item(0)->textContent);
+            }
+
+            // Priority 3: Any dateTime in metadata
+            $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime');
+            if ($dateNodes && $dateNodes->length > 0) {
+                return $this->formatDate($dateNodes->item(0)->textContent);
+            }
+
+            // SCORM 1.2: Look for <schema> and <schemaversion> to get creation context
+            $schemaNodes = $this->safeXPathQuery($xpath, '//schema');
+            if ($schemaNodes && $schemaNodes->length > 0) {
+                $schema = $schemaNodes->item(0)->textContent;
+                if (strpos($schema, 'ADL SCORM') !== false) {
+                    // For SCORM 1.2, we might not have creation date in manifest
+                    // Return null as it's not standard in SCORM 1.2
+                    return null;
+                }
+            }
+        } catch (\Exception $e) {
+            \Log::warning('extractCreationDate: Error extracting creation date - ' . $e->getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract creator from SCORM manifest metadata following SCORM standards
+     */
+    private function extractCreator(DOMDocument $dom)
+    {
+        try {
+            $xpath = new \DOMXPath($dom);
+
+            // Register common SCORM namespaces with error handling
+            $this->registerScormNamespaces($xpath);
+
+            // SCORM 2004: Look for lom:lom/lom:lifeCycle/lom:contribute/lom:entity
+            // Priority 1: Creator role
+            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="creator"]]]');
+            if ($entityNodes && $entityNodes->length > 0) {
+                return trim($entityNodes->item(0)->textContent);
+            }
+
+            // Priority 2: Author role
+            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="author"]]]');
+            if ($entityNodes && $entityNodes->length > 0) {
+                return trim($entityNodes->item(0)->textContent);
+            }
+
+            // Priority 3: Publisher role
+            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="publisher"]]]');
+            if ($entityNodes && $entityNodes->length > 0) {
+                return trim($entityNodes->item(0)->textContent);
+            }
+
+            // Priority 4: Any entity in contribute section
+            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute]');
+            if ($entityNodes && $entityNodes->length > 0) {
+                return trim($entityNodes->item(0)->textContent);
+            }
+
+            // Priority 5: Any entity in metadata
+            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity');
+            if ($entityNodes && $entityNodes->length > 0) {
+                return trim($entityNodes->item(0)->textContent);
+            }
+
+            // SCORM 1.2: Look for organization or other creator information
+            // SCORM 1.2 typically doesn't have detailed creator metadata
+            $orgNodes = $this->safeXPathQuery($xpath, '//organization');
+            if ($orgNodes && $orgNodes->length > 0) {
+                // For SCORM 1.2, we might not have creator info in manifest
+                return null;
+            }
+        } catch (\Exception $e) {
+            \Log::warning('extractCreator: Error extracting creator - ' . $e->getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * Format date string to ISO 8601 format
+     */
+    private function formatDate($dateString)
+    {
+        if (empty($dateString)) {
+            return null;
+        }
+
+        // Try to parse the date and convert to ISO 8601
+        try {
+            $date = new \DateTime($dateString);
+            return $date->format('c'); // ISO 8601 format
+        } catch (\Exception $e) {
+            // If parsing fails, return the original string
+            return trim($dateString);
+        }
+    }
+
+    /**
+     * Register SCORM namespaces safely
+     */
+    private function registerScormNamespaces(\DOMXPath $xpath)
+    {
+        try {
+            $xpath->registerNamespace('lom', 'http://ltsc.ieee.org/xsd/LOM');
+            $xpath->registerNamespace('adlcp', 'http://www.adlnet.org/xsd/adlcp_v1p3');
+            $xpath->registerNamespace('adlseq', 'http://www.adlnet.org/xsd/adlseq_v1p3');
+            $xpath->registerNamespace('adlnav', 'http://www.adlnet.org/xsd/adlnav_v1p3');
+        } catch (\Exception $e) {
+            \Log::warning('registerScormNamespaces: Error registering namespaces - ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Execute XPath query safely with error handling
+     */
+    private function safeXPathQuery(\DOMXPath $xpath, $query)
+    {
+        try {
+            return $xpath->query($query);
+        } catch (\Exception $e) {
+            \Log::warning('safeXPathQuery: Error executing XPath query "' . $query . '" - ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Fix XML entities by escaping unescaped ampersands while preserving CDATA sections
+     * 
+     * @param string $xml
+     * @return string
+     */
+    private function fixXmlEntities($xml)
+    {
+        // Extract CDATA sections with placeholders
+        $cdataSections = [];
+        $xml = preg_replace_callback(
+            '/<!\[CDATA\[(.*?)\]\]>/s',
+            function ($matches) use (&$cdataSections) {
+                $placeholder = '__CDATA_' . count($cdataSections) . '__';
+                $cdataSections[$placeholder] = $matches[0];
+                return $placeholder;
+            },
+            $xml
+        );
+
+        // Escape ampersands not part of valid XML entities
+        // Valid: &name; &#123; &#xAB; &#XAB;
+        $xml = preg_replace('/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);)/', '&amp;', $xml);
+
+        // Restore CDATA sections
+        return str_replace(array_keys($cdataSections), $cdataSections, $xml);
+    }
+
+    /**
+     * Clean resources and throw exception.
+     */
+    private function onError($msg)
     {
         $this->scormDisk->deleteScorm($this->uuid);
         throw new InvalidScormArchiveException($msg);

--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -1,14 +1,17 @@
 <?php
 
-
 namespace Peopleaps\Scorm\Manager;
 
 use Carbon\Carbon;
+use DateInterval;
+use DateTime;
 use DOMDocument;
+use DOMXPath;
+use Exception;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Peopleaps\Scorm\Entity\Scorm;
+use Peopleaps\Scorm\Entity\Sco;
 use Peopleaps\Scorm\Entity\ScoTracking;
 use Peopleaps\Scorm\Exception\InvalidScormArchiveException;
 use Peopleaps\Scorm\Library\ScormLib;
@@ -16,481 +19,125 @@ use Peopleaps\Scorm\Model\ScormModel;
 use Peopleaps\Scorm\Model\ScormScoModel;
 use Peopleaps\Scorm\Model\ScormScoTrackingModel;
 use Illuminate\Support\Str;
-use Peopleaps\Scorm\Entity\Sco;
+use ZipArchive;
+use Illuminate\Support\Facades\Log;
 
 class ScormManager
 {
-    /** @var ScormLib */
-    private $scormLib;
-    /** @var ScormDisk */
-    private $scormDisk;
-    /** @var string $uuid */
-    private $uuid;
+    private ScormLib  $scormLib;
+    private ScormDisk $scormDisk;
 
     /**
-     * Constructor.
-     *
-     * @param string $filesDir
-     * @param string $uploadDir
+     * The UUID for the current upload operation.
+     * Scoped per-call via uploadScormArchive / uploadScormFromUri
+     * so the class is safe to reuse across requests.
      */
+    private string $uuid;
+
+    // -------------------------------------------------------------------------
+    // SCORM status priority for comparison logic
+    // -------------------------------------------------------------------------
+
+    private const STATUS_PRIORITY = [
+        'unknown'       => 0,
+        'not attempted' => 1,
+        'browsed'       => 2,
+        'incomplete'    => 3,
+        'completed'     => 4,
+        'failed'        => 5,
+        'passed'        => 6,
+    ];
+
     public function __construct()
     {
-        $this->scormLib = new ScormLib();
+        $this->scormLib  = new ScormLib();
         $this->scormDisk = new ScormDisk();
     }
 
-    public function uploadScormFromUri($file, $uuid = null)
-    {
-        // $uuid is meant for user to update scorm content. Hence, if user want to update content should parse in existing uuid
-        $this->uuid =  $uuid ?? Str::uuid()->toString();
+    // =========================================================================
+    // Upload
+    // =========================================================================
 
-        // Validate that the file parameter is not empty
+    /**
+     * Upload a SCORM package that already lives on the archive S3 bucket.
+     *
+     * @param  string       $file  S3 object key inside the archive bucket.
+     * @param  string|null  $uuid  Supply an existing UUID to replace that package.
+     * @return ScormModel
+     */
+    public function uploadScormFromUri(string $file, ?string $uuid = null): ScormModel
+    {
         if (empty($file)) {
             throw new InvalidScormArchiveException('file_parameter_empty');
         }
 
-        // Log the file being processed for debugging
-        \Log::info('Uploading SCORM from URI: ' . $file);
+        $this->uuid = $uuid ?? Str::uuid()->toString();
+
+        Log::info('ScormManager::uploadScormFromUri — processing: ' . $file);
 
         $scorm = null;
-        $this->scormDisk->readScormArchive($file, function ($path) use (&$scorm, $file, $uuid) {
-            $filename = basename($file);
-            $scorm = $this->saveScorm($path, $filename, $uuid);
+        $this->scormDisk->readScormArchive($file, function (string $tmpPath) use (&$scorm, $file, $uuid) {
+            $scorm = $this->saveScorm($tmpPath, basename($file), $uuid);
         });
+
         return $scorm;
     }
 
     /**
-     * @param UploadedFile $file
-     * @param null|string $uuid
+     * Upload a SCORM package from a local/uploaded file.
+     *
+     * @param  UploadedFile  $file
+     * @param  string|null   $uuid  Supply an existing UUID to replace that package.
      * @return ScormModel
-     * @throws InvalidScormArchiveException
      */
-    public function uploadScormArchive(UploadedFile $file, $uuid = null)
+    public function uploadScormArchive(UploadedFile $file, ?string $uuid = null): ScormModel
     {
-        // $uuid is meant for user to update scorm content. Hence, if user want to update content should parse in existing uuid
-        $this->uuid =  $uuid ?? Str::uuid()->toString();
+        $this->uuid = $uuid ?? Str::uuid()->toString();
 
         return $this->saveScorm($file, $file->getClientOriginalName(), $uuid);
     }
 
+    // =========================================================================
+    // SCO / Tracking queries
+    // =========================================================================
+
     /**
-     * Find imsmanifest.xml location in ZIP archive
-     * 
-     * @param \ZipArchive $zip
-     * @return array ['found' => bool, 'path' => string, 'stream' => resource|null]
+     * @return \Illuminate\Database\Eloquent\Collection<ScormScoModel>
      */
-    private function findManifestInZip(\ZipArchive $zip)
+    public function getScos(int $scormId)
     {
-        // Look for imsmanifest.xml in root directory first
-        $manifestStream = $zip->getStream('imsmanifest.xml');
-
-        if ($manifestStream) {
-            \Log::info('Found imsmanifest.xml in root directory');
-            return [
-                'found' => true,
-                'path' => 'imsmanifest.xml',
-                'stream' => $manifestStream
-            ];
-        }
-
-        // Search for imsmanifest.xml in subdirectories
-        \Log::info('imsmanifest.xml not found in root, searching subdirectories...');
-
-        for ($i = 0; $i < $zip->numFiles; $i++) {
-            $filename = $zip->getNameIndex($i);
-
-            // Check if this file is imsmanifest.xml (case insensitive)
-            if (strtolower(basename($filename)) === 'imsmanifest.xml') {
-                $manifestStream = $zip->getStream($filename);
-                if ($manifestStream) {
-                    \Log::info('Found imsmanifest.xml at: ' . $filename);
-                    return [
-                        'found' => true,
-                        'path' => $filename,
-                        'stream' => $manifestStream
-                    ];
-                }
-            }
-        }
-
-        return [
-            'found' => false,
-            'path' => '',
-            'stream' => null
-        ];
+        return ScormScoModel::with('scorm')->where('scorm_id', $scormId)->get();
     }
 
     /**
-     *  Checks if it is a valid scorm archive
-     * 
-     * @param string|UploadedFile $file zip.       
+     * @return ScormScoModel
      */
-    private function validatePackage($file)
+    public function getScoByUuid(string $scoUuid): ScormScoModel
     {
-        $zip = new \ZipArchive();
-        $manifestResult = null;
-
-        try {
-            $openValue = $zip->open($file);
-
-            if ($openValue !== true) {
-                \Log::error('Zip open errorCode: ' . $openValue);
-                $this->onError('invalid_scorm_archive_message');
-            }
-
-            $manifestResult = $this->findManifestInZip($zip);
-        } finally {
-            // Always close resources
-            if ($manifestResult && $manifestResult['stream'] && is_resource($manifestResult['stream'])) {
-                fclose($manifestResult['stream']);
-            }
-            $zip->close();
-        }
-
-        if (!$manifestResult['found']) {
-            \Log::error('imsmanifest.xml not found anywhere in the ZIP archive');
-            $this->onError('invalid_scorm_archive_message');
-        }
-
-        \Log::info('SCORM archive validation successful. Manifest found at: ' . $manifestResult['path']);
+        return ScormScoModel::with('scorm')->where('uuid', $scoUuid)->firstOrFail();
     }
 
-    /**
-     *  Save scorm data
-     *
-     * @param string|UploadedFile $file zip.
-     * @param string $filename
-     * @param null|string $uuid
-     * @return ScormModel
-     * @throws InvalidScormArchiveException
-     */
-    private function saveScorm($file, $filename, $uuid = null)
+    public function getUserResult(int $scoId, int $userId): ?ScormScoTrackingModel
     {
-        $this->validatePackage($file);
-        $scormData  =   $this->generateScorm($file);
-        // save to db
-        if (is_null($scormData) || !is_array($scormData)) {
-            $this->onError('invalid_scorm_data');
-        }
-
-        // This uuid is use when the admin wants to edit existing scorm file.
-        if (!empty($uuid)) {
-            $this->uuid =   $uuid; // Overwrite system generated uuid
-        }
-
-        /**
-         * ScormModel::whereUuid Query Builder style equals ScormModel::where('uuid',$value)
-         * 
-         * From Laravel doc https://laravel.com/docs/5.0/queries#advanced-wheres.
-         * Dynamic Where Clauses
-         * You may even use "dynamic" where statements to fluently build where statements using magic methods:
-         * 
-         * Examples: 
-         * 
-         * $admin = DB::table('users')->whereId(1)->first();
-         * From laravel framework https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Query/Builder.php'
-         *  Handle dynamic method calls into the method.
-         *  return $this->dynamicWhere($method, $parameters);
-         **/
-        // $scorm = ScormModel::whereOriginFile($filename);
-        // Uuid indicator is better than filename for update content or add new content.
-        $scorm = ScormModel::where('uuid', $this->uuid);
-
-        // Check if scom package already exists to drop old one.
-        if (!$scorm->exists()) {
-            $scorm = new ScormModel();
-        } else {
-            $scorm = $scorm->first();
-            $this->deleteScormData($scorm);
-        }
-
-        $scorm->uuid =   $this->uuid;
-        $scorm->title =   $scormData['title'];
-        $scorm->version =   $scormData['version'];
-        $scorm->entry_url =   $scormData['entryUrl'];
-        $scorm->identifier =   $scormData['identifier'];
-        $scorm->origin_file =   $filename;
-
-        // Auto-detect and set metadata
-        $scorm->metadata = [
-            'package_size' => $this->getFileSize($file),
-            'created_at' => $scormData['created_at'] ?? null,
-            'created_by' => $scormData['created_by'] ?? null
-        ];
-
-        $scorm->save();
-
-        if (!empty($scormData['scos']) && is_array($scormData['scos'])) {
-            \Log::info('saveScorm: Saving ' . count($scormData['scos']) . ' SCOs');
-            /** @var Sco $scoData */
-            foreach ($scormData['scos'] as $scoData) {
-                $this->saveScormScosRecursively($scorm->id, $scoData);
-            }
-        } else {
-            \Log::warning('saveScorm: No SCOs to save');
-        }
-
-        return  $scorm;
+        return ScormScoTrackingModel::where('sco_id', $scoId)
+            ->where('user_id', $userId)
+            ->first();
     }
 
-    /**
-     * Save Scorm sco and it's nested children recursively
-     * @param int $scorm_id scorm id.
-     * @param Sco $scoData Sco data to be store.
-     * @param int $sco_parent_id sco parent id for children
-     */
-    private function saveScormScosRecursively($scorm_id, $scoData, $sco_parent_id = null)
+    // =========================================================================
+    // Tracking
+    // =========================================================================
+
+    public function createScoTracking(string $scoUuid, $userId = null, $userName = null): ScoTracking
     {
-        $sco = $this->saveScormScos($scorm_id, $scoData, $sco_parent_id);
-
-        // Recursively save children
-        if ($scoData->scoChildren && is_array($scoData->scoChildren)) {
-            foreach ($scoData->scoChildren as $scoChild) {
-                $this->saveScormScosRecursively($scorm_id, $scoChild, $sco->id);
-            }
-        }
-
-        return $sco;
-    }
-
-    /**
-     * Save Scorm sco and it's nested children
-     * @param int $scorm_id scorm id.
-     * @param Sco $scoData Sco data to be store.
-     * @param int $sco_parent_id sco parent id for children
-     */
-    private function saveScormScos($scorm_id, $scoData, $sco_parent_id = null)
-    {
-        $sco    =   new ScormScoModel();
-        $sco->scorm_id  =   $scorm_id;
-        $sco->uuid  =   $scoData->uuid;
-        $sco->sco_parent_id  =   $sco_parent_id;
-        $sco->entry_url  =   $scoData->entryUrl;
-        $sco->identifier  =   $scoData->identifier;
-        $sco->title  =   $scoData->title;
-        $sco->visible  =   $scoData->visible;
-        $sco->sco_parameters  =   $scoData->parameters;
-        $sco->launch_data  =   $scoData->launchData;
-        $sco->max_time_allowed  =   $scoData->maxTimeAllowed;
-        $sco->time_limit_action  =   $scoData->timeLimitAction;
-        $sco->block  =   $scoData->block;
-        $sco->score_int  =   $scoData->scoreToPassInt;
-        $sco->score_decimal  =   $scoData->scoreToPassDecimal;
-        $sco->completion_threshold  =   $scoData->completionThreshold;
-        $sco->prerequisites  =   $scoData->prerequisites;
-
-        $sco->save();
-
-        \Log::info("saveScormScos: Saved SCO - " . $sco->identifier);
-        return $sco;
-    }
-
-    /**
-     * @param string|UploadedFile $file zip.       
-     */
-    private function parseScormArchive($file)
-    {
-        $data = [];
-        $contents = '';
-        $zip = new \ZipArchive();
-        $manifestResult = null;
-
-        try {
-            $openValue = $zip->open($file);
-
-            if ($openValue !== true) {
-                \Log::error('Failed to open ZIP file in parseScormArchive. Error code: ' . $openValue);
-                $this->onError('cannot_load_imsmanifest_message');
-            }
-
-            $manifestResult = $this->findManifestInZip($zip);
-
-            if (!$manifestResult['found']) {
-                $this->onError('cannot_load_imsmanifest_message');
-            }
-
-            while (!feof($manifestResult['stream'])) {
-                $contents .= fread($manifestResult['stream'], 2);
-            }
-        } finally {
-            // Always close resources
-            if ($manifestResult && $manifestResult['stream'] && is_resource($manifestResult['stream'])) {
-                fclose($manifestResult['stream']);
-            }
-            $zip->close();
-        }
-
-        $dom = new DOMDocument();
-
-        // Fix XML entity errors by escaping unescaped ampersands
-        $contents = $this->fixXmlEntities($contents);
-
-        if (!$dom->loadXML($contents)) {
-            $this->onError('cannot_load_imsmanifest_message');
-        }
-
-        $manifest = $dom->getElementsByTagName('manifest')->item(0);
-        if (!is_null($manifest->attributes->getNamedItem('identifier'))) {
-            $data['identifier'] = $manifest->attributes->getNamedItem('identifier')->nodeValue;
-        } else {
-            $this->onError('invalid_scorm_manifest_identifier');
-        }
-        $titles = $dom->getElementsByTagName('title');
-        if ($titles->length > 0) {
-            $data['title'] = Str::of($titles->item(0)->textContent)->trim('/n')->trim();
-        }
-
-        $scormVersionElements = $dom->getElementsByTagName('schemaversion');
-        if ($scormVersionElements->length > 0) {
-            switch ($scormVersionElements->item(0)->textContent) {
-                case '1.2':
-                    $data['version'] = Scorm::SCORM_12;
-                    break;
-                case 'CAM 1.3':
-                case '2004 3rd Edition':
-                case '2004 4th Edition':
-                    $data['version'] = Scorm::SCORM_2004;
-                    break;
-                default:
-                    $this->onError('invalid_scorm_version_message');
-            }
-        } else {
-            $this->onError('invalid_scorm_version_message');
-        }
-        $scos = $this->scormLib->parseOrganizationsNode($dom);
-
-        if (0 >= count($scos)) {
-            \Log::error('parseScormArchive: No SCOs found in SCORM archive');
-            $this->onError('no_sco_in_scorm_archive_message');
-        }
-
-        $data['entryUrl'] = $scos[0]->entryUrl ?? $scos[0]->scoChildren[0]->entryUrl;
-        $data['scos'] = $scos;
-
-        \Log::info('parseScormArchive: Found ' . count($scos) . ' SCOs, entryUrl: ' . $data['entryUrl']);
-
-        // Include manifest path for later use in entry URL adjustment
-        $data['manifestPath'] = $manifestResult['path'];
-
-        // Extract creation date and creator from manifest metadata
-        $data['created_at'] = $this->extractCreationDate($dom);
-        $data['created_by'] = $this->extractCreator($dom);
-
-        return $data;
-    }
-
-    public function deleteScorm($model)
-    {
-        // Delete after the previous item is stored
-        if ($model) {
-            $this->deleteScormData($model);
-            $model->delete(); // delete scorm
-        }
-    }
-
-    private function deleteScormData($model)
-    {
-        // Delete after the previous item is stored
-        $oldScos = $model->scos()->get();
-
-        // Delete all tracking associate with sco
-        foreach ($oldScos as $oldSco) {
-            $oldSco->scoTrackings()->delete();
-        }
-        $model->scos()->delete(); // delete scos
-        // Delete folder from server
-        $this->deleteScormFolder($model->uuid);
-    }
-
-    /**
-     * @param $folderHashedName
-     * @return bool
-     */
-    protected function deleteScormFolder($folderHashedName)
-    {
-        return $this->scormDisk->deleteScorm($folderHashedName);
-    }
-
-    /**
-     * @param string|UploadedFile $file zip.       
-     * @return array
-     * @throws InvalidScormArchiveException
-     */
-    private function generateScorm($file)
-    {
-        $scormData = $this->parseScormArchive($file);
-        /**
-         * Unzip a given ZIP file into the web resources directory.
-         *
-         * @param string $hashName name of the destination directory
-         */
-        $this->scormDisk->unzipper($file, $this->uuid);
-
-        // Update main entry URL to include root path if content is in subdirectory
-        // Use the manifest path we already calculated during parsing
-        if (isset($scormData['manifestPath']) && strpos($scormData['manifestPath'], '/') !== false) {
-            $parentPath = dirname($scormData['manifestPath']);
-            $originalEntryUrl = $scormData['entryUrl'];
-            $scormData['entryUrl'] = $parentPath . '/' . ltrim($scormData['entryUrl'], '/');
-            \Log::info("SCORM content in subdirectory '{$parentPath}'. Entry URL: {$originalEntryUrl} -> {$scormData['entryUrl']}");
-        } else {
-            \Log::info("SCORM content in root directory. Entry URL unchanged: {$scormData['entryUrl']}");
-        }
-
-        return [
-            'identifier' => $scormData['identifier'],
-            'uuid' => $this->uuid,
-            'title' => $scormData['title'], // to follow standard file data format
-            'version' => $scormData['version'],
-            'entryUrl' => $scormData['entryUrl'],
-            'scos' => $scormData['scos'],
-        ];
-    }
-
-    /**
-     * Get SCO list
-     * @param $scormId
-     * @return \Illuminate\Database\Eloquent\Builder[]|\Illuminate\Database\Eloquent\Collection
-     */
-    public function getScos($scormId)
-    {
-        $scos  =   ScormScoModel::with([
-            'scorm'
-        ])->where('scorm_id', $scormId)
-            ->get();
-
-        return $scos;
-    }
-
-    /**
-     * Get sco by uuid
-     * @param $scoUuid
-     * @return null|\Illuminate\Database\Eloquent\Builder|Model
-     */
-    public function getScoByUuid($scoUuid)
-    {
-        $sco    =   ScormScoModel::with(['scorm'])
-            ->where('uuid', $scoUuid)
-            ->firstOrFail();
-
-        return $sco;
-    }
-
-    public function getUserResult($scoId, $userId)
-    {
-        return ScormScoTrackingModel::where('sco_id', $scoId)->where('user_id', $userId)->first();
-    }
-
-    public function createScoTracking($scoUuid, $userId = null, $userName = null)
-    {
-        $sco    =   ScormScoModel::where('uuid', $scoUuid)->firstOrFail();
-
+        $sco     = ScormScoModel::where('uuid', $scoUuid)->firstOrFail();
         $version = $sco->scorm->version;
+
         $scoTracking = new ScoTracking();
         $scoTracking->setSco($sco->toArray());
 
         $cmi = null;
+
         switch ($version) {
             case Scorm::SCORM_12:
                 $scoTracking->setLessonStatus('not attempted');
@@ -502,28 +149,25 @@ class ScormManager
                 $scoTracking->setSessionTime(0);
                 $scoTracking->setLessonMode('normal');
                 $scoTracking->setExitMode('');
+                $scoTracking->setIsLocked(!is_null($sco->prerequisites));
 
-                if (is_null($sco->prerequisites)) {
-                    $scoTracking->setIsLocked(false);
-                } else {
-                    $scoTracking->setIsLocked(true);
-                }
                 $cmi = [
-                    'cmi.core.entry' => $scoTracking->getEntry(),
-                    'cmi.core.student_id' => $userId,
+                    'cmi.core.entry'        => $scoTracking->getEntry(),
+                    'cmi.core.student_id'   => $userId,
                     'cmi.core.student_name' => $userName,
                 ];
-
                 break;
+
             case Scorm::SCORM_2004:
                 $scoTracking->setTotalTimeString('PT0S');
                 $scoTracking->setCompletionStatus('unknown');
                 $scoTracking->setLessonStatus('unknown');
                 $scoTracking->setIsLocked(false);
+
                 $cmi = [
-                    'cmi.entry' => 'ab-initio',
-                    'cmi.learner_id' =>  $userId,
-                    'cmi.learner_name' => $userName,
+                    'cmi.entry'               => 'ab-initio',
+                    'cmi.learner_id'          => $userId,
+                    'cmi.learner_name'        => $userName,
                     'cmi.scaled_passing_score' => 0.5,
                 ];
                 break;
@@ -532,537 +176,795 @@ class ScormManager
         $scoTracking->setUserId($userId);
         $scoTracking->setDetails($cmi);
 
-        // Create a new tracking model
-        $storeTracking  =   ScormScoTrackingModel::firstOrCreate([
-            'user_id'   =>  $userId,
-            'sco_id'    =>  $sco->id
-        ], [
-            'uuid'  =>   Str::uuid()->toString(),
-            'progression'  =>  $scoTracking->getProgression(),
-            'score_raw'  =>  $scoTracking->getScoreRaw(),
-            'score_min'  =>  $scoTracking->getScoreMin(),
-            'score_max'  =>  $scoTracking->getScoreMax(),
-            'score_scaled'  =>  $scoTracking->getScoreScaled(),
-            'lesson_status'  =>  $scoTracking->getLessonStatus(),
-            'completion_status'  =>  $scoTracking->getCompletionStatus(),
-            'session_time'  =>  $scoTracking->getSessionTime(),
-            'total_time_int'  =>  $scoTracking->getTotalTimeInt(),
-            'total_time_string'  =>  $scoTracking->getTotalTimeString(),
-            'entry'  =>  $scoTracking->getEntry(),
-            'suspend_data'  =>  $scoTracking->getSuspendData(),
-            'credit'  =>  $scoTracking->getCredit(),
-            'exit_mode'  =>  $scoTracking->getExitMode(),
-            'lesson_location'  =>  $scoTracking->getLessonLocation(),
-            'lesson_mode'  =>  $scoTracking->getLessonMode(),
-            'is_locked'  =>  $scoTracking->getIsLocked(),
-            'details'  =>  $scoTracking->getDetails(),
-            'latest_date'  =>  $scoTracking->getLatestDate(),
-            'created_at'  =>  Carbon::now(),
-            'updated_at'  =>  Carbon::now(),
-        ]);
+        $stored = ScormScoTrackingModel::firstOrCreate(
+            ['user_id' => $userId, 'sco_id' => $sco->id],
+            [
+                'uuid'               => Str::uuid()->toString(),
+                'progression'        => $scoTracking->getProgression(),
+                'score_raw'          => $scoTracking->getScoreRaw(),
+                'score_min'          => $scoTracking->getScoreMin(),
+                'score_max'          => $scoTracking->getScoreMax(),
+                'score_scaled'       => $scoTracking->getScoreScaled(),
+                'lesson_status'      => $scoTracking->getLessonStatus(),
+                'completion_status'  => $scoTracking->getCompletionStatus(),
+                'session_time'       => $scoTracking->getSessionTime(),
+                'total_time_int'     => $scoTracking->getTotalTimeInt(),
+                'total_time_string'  => $scoTracking->getTotalTimeString(),
+                'entry'              => $scoTracking->getEntry(),
+                'suspend_data'       => $scoTracking->getSuspendData(),
+                'credit'             => $scoTracking->getCredit(),
+                'exit_mode'          => $scoTracking->getExitMode(),
+                'lesson_location'    => $scoTracking->getLessonLocation(),
+                'lesson_mode'        => $scoTracking->getLessonMode(),
+                'is_locked'          => $scoTracking->getIsLocked(),
+                'details'            => $scoTracking->getDetails(),
+                'latest_date'        => $scoTracking->getLatestDate(),
+                'created_at'         => Carbon::now(),
+                'updated_at'         => Carbon::now(),
+            ]
+        );
 
-        $scoTracking->setUuid($storeTracking->uuid);
-        $scoTracking->setProgression($storeTracking->progression);
-        $scoTracking->setScoreRaw($storeTracking->score_raw);
-        $scoTracking->setScoreMin($storeTracking->score_min);
-        $scoTracking->setScoreMax($storeTracking->score_max);
-        $scoTracking->setScoreScaled($storeTracking->score_scaled);
-        $scoTracking->setLessonStatus($storeTracking->lesson_status);
-        $scoTracking->setCompletionStatus($storeTracking->completion_status);
-        $scoTracking->setSessionTime($storeTracking->session_time);
-        $scoTracking->setTotalTimeInt($storeTracking->total_time_int);
-        $scoTracking->setTotalTimeString($storeTracking->total_time_string);
-        $scoTracking->setEntry($storeTracking->entry);
-        $scoTracking->setSuspendData($storeTracking->suspend_data);
-        $scoTracking->setCredit($storeTracking->credit);
-        $scoTracking->setExitMode($storeTracking->exit_mode);
-        $scoTracking->setLessonLocation($storeTracking->lesson_location);
-        $scoTracking->setLessonMode($storeTracking->lesson_mode);
-        $scoTracking->setIsLocked($storeTracking->is_locked);
-        $scoTracking->setDetails($storeTracking->details);
-        $scoTracking->setLatestDate(Carbon::parse($storeTracking->latest_date));
+        $this->hydrateTrackingFromModel($scoTracking, $stored);
 
         return $scoTracking;
     }
 
-    public function findScoTrackingId($scoUuid, $scoTrackingUuid)
+    public function findScoTrackingId(string $scoUuid, string $scoTrackingUuid): ScormScoTrackingModel
     {
-        return ScormScoTrackingModel::with([
-            'sco'
-        ])->whereHas('sco', function (Builder $query) use ($scoUuid) {
-            $query->where('uuid', $scoUuid);
-        })->where('uuid', $scoTrackingUuid)
+        return ScormScoTrackingModel::with('sco')
+            ->whereHas('sco', fn(Builder $q) => $q->where('uuid', $scoUuid))
+            ->where('uuid', $scoTrackingUuid)
             ->firstOrFail();
     }
 
-    public function checkUserIsCompletedScorm($scormId, $userId)
+    public function checkUserIsCompletedScorm(int $scormId, int $userId): bool
     {
+        $scos = ScormScoModel::where('scorm_id', $scormId)->get();
 
-        $completedSco    =   [];
-        $scos   =   ScormScoModel::where('scorm_id', $scormId)->get();
+        $completedCount = $scos->filter(function ($sco) use ($userId) {
+            $tracking = ScormScoTrackingModel::where('sco_id', $sco->id)
+                ->where('user_id', $userId)
+                ->first();
 
-        foreach ($scos as $sco) {
-            $scoTracking    =   ScormScoTrackingModel::where('sco_id', $sco->id)->where('user_id', $userId)->first();
+            return $tracking && in_array($tracking->lesson_status, ['passed', 'completed'], true);
+        })->count();
 
-            if ($scoTracking && ($scoTracking->lesson_status == 'passed' || $scoTracking->lesson_status == 'completed')) {
-                $completedSco[] =   true;
+        return $completedCount === $scos->count();
+    }
+
+    public function updateScoTracking(string $scoUuid, int $userId, array $data): ScormScoTrackingModel
+    {
+        $tracking = $this->createScoTracking($scoUuid, $userId);
+        $tracking->setLatestDate(Carbon::now());
+
+        $sco   = $tracking->getSco();
+        $scorm = ScormModel::where('id', $sco['scorm_id'])->firstOrFail();
+
+        match ($scorm->version) {
+            Scorm::SCORM_12   => $this->applyScorm12Data($tracking, $data),
+            Scorm::SCORM_2004 => $this->applyScorm2004Data($tracking, $data),
+        };
+
+        return ScormScoTrackingModel::where('user_id', $tracking->getUserId())
+            ->where('sco_id', $sco['id'])
+            ->firstOrFail()
+            ->tap(function (ScormScoTrackingModel $model) use ($tracking) {
+                $model->progression       = $tracking->getProgression();
+                $model->score_raw         = $tracking->getScoreRaw();
+                $model->score_min         = $tracking->getScoreMin();
+                $model->score_max         = $tracking->getScoreMax();
+                $model->score_scaled      = $tracking->getScoreScaled();
+                $model->lesson_status     = $tracking->getLessonStatus();
+                $model->completion_status = $tracking->getCompletionStatus();
+                $model->session_time      = $tracking->getSessionTime();
+                $model->total_time_int    = $tracking->getTotalTimeInt();
+                $model->total_time_string = $tracking->getTotalTimeString();
+                $model->entry             = $tracking->getEntry();
+                $model->suspend_data      = $tracking->getSuspendData();
+                $model->exit_mode         = $tracking->getExitMode();
+                $model->credit            = $tracking->getCredit();
+                $model->lesson_location   = $tracking->getLessonLocation();
+                $model->lesson_mode       = $tracking->getLessonMode();
+                $model->is_locked         = $tracking->getIsLocked();
+                $model->details           = $tracking->getDetails();
+                $model->latest_date       = $tracking->getLatestDate();
+                $model->save();
+            });
+    }
+
+    public function resetUserData(int $scormId, int $userId): void
+    {
+        ScormScoModel::where('scorm_id', $scormId)
+            ->get()
+            ->each(function (ScormScoModel $sco) use ($userId) {
+                ScormScoTrackingModel::where('sco_id', $sco->id)
+                    ->where('user_id', $userId)
+                    ->delete();
+            });
+    }
+
+    // =========================================================================
+    // Delete
+    // =========================================================================
+
+    public function deleteScorm(ScormModel $model): void
+    {
+        if (!$model) {
+            return;
+        }
+
+        $this->deleteScormData($model);
+        $model->delete();
+    }
+
+    // =========================================================================
+    // Private — persistence
+    // =========================================================================
+
+    /**
+     * Orchestrates validation → parsing → extraction → DB persistence.
+     *
+     * @param  string|UploadedFile  $file
+     */
+    private function saveScorm($file, string $filename, ?string $uuid = null): ScormModel
+    {
+        $this->validatePackage($file);
+
+        $scormData = $this->generateScorm($file);
+
+        if (empty($scormData) || !is_array($scormData)) {
+            $this->onError('invalid_scorm_data');
+        }
+
+        // An explicit UUID overrides the one generated at upload-entry.
+        if (!empty($uuid)) {
+            $this->uuid = $uuid;
+        }
+
+        $scorm = ScormModel::where('uuid', $this->uuid)->first();
+
+        if ($scorm === null) {
+            $scorm = new ScormModel();
+        } else {
+            $this->deleteScormData($scorm);
+        }
+
+        $scorm->uuid         = $this->uuid;
+        $scorm->title        = $scormData['title'];
+        $scorm->version      = $scormData['version'];
+        $scorm->entry_url    = $scormData['entryUrl'];
+        $scorm->identifier   = $scormData['identifier'];
+        $scorm->origin_file  = $filename;
+        $scorm->metadata     = [
+            'package_size' => $this->getFileSize($file),
+            'created_at'   => $scormData['created_at'] ?? null,
+            'created_by'   => $scormData['created_by'] ?? null,
+        ];
+        $scorm->save();
+
+        if (!empty($scormData['scos'])) {
+            Log::info('ScormManager::saveScorm — saving ' . count($scormData['scos']) . ' SCO(s)');
+            foreach ($scormData['scos'] as $scoData) {
+                $this->saveScormScosRecursively($scorm->id, $scoData);
+            }
+        } else {
+            Log::warning('ScormManager::saveScorm — no SCOs found in parsed data');
+        }
+
+        return $scorm;
+    }
+
+    private function saveScormScosRecursively(int $scormId, Sco $scoData, ?int $parentId = null): ScormScoModel
+    {
+        $sco = $this->persistSco($scormId, $scoData, $parentId);
+
+        if (!empty($scoData->scoChildren) && is_array($scoData->scoChildren)) {
+            foreach ($scoData->scoChildren as $child) {
+                $this->saveScormScosRecursively($scormId, $child, $sco->id);
             }
         }
 
-        if (count($completedSco) == $scos->count()) {
-            return true;
-        } else {
+        return $sco;
+    }
+
+    private function persistSco(int $scormId, Sco $scoData, ?int $parentId = null): ScormScoModel
+    {
+        $sco = new ScormScoModel([
+            'scorm_id'            => $scormId,
+            'uuid'                => $scoData->uuid,
+            'sco_parent_id'       => $parentId,
+            'entry_url'           => $scoData->entryUrl,
+            'identifier'          => $scoData->identifier,
+            'title'               => $scoData->title,
+            'visible'             => $scoData->visible,
+            'sco_parameters'      => $scoData->parameters,
+            'launch_data'         => $scoData->launchData,
+            'max_time_allowed'    => $scoData->maxTimeAllowed,
+            'time_limit_action'   => $scoData->timeLimitAction,
+            'block'               => $scoData->block,
+            'score_int'           => $scoData->scoreToPassInt,
+            'score_decimal'       => $scoData->scoreToPassDecimal,
+            'completion_threshold' => $scoData->completionThreshold,
+            'prerequisites'       => $scoData->prerequisites,
+        ]);
+
+        $sco->save();
+
+        Log::info('ScormManager::persistSco — saved SCO: ' . $sco->identifier);
+
+        return $sco;
+    }
+
+    private function deleteScormData(ScormModel $model): void
+    {
+        $model->scos()->each(function (ScormScoModel $sco) {
+            $sco->scoTrackings()->delete();
+        });
+
+        $model->scos()->delete();
+        $this->scormDisk->deleteScorm($model->uuid);
+    }
+
+    // =========================================================================
+    // Private — SCORM package parsing
+    // =========================================================================
+
+    /**
+     * Open the zip and confirm imsmanifest.xml is present.
+     *
+     * @param  string|UploadedFile  $file
+     */
+    private function validatePackage($file): void
+    {
+        $zip            = new ZipArchive();
+        $manifestResult = null;
+
+        try {
+            if ($zip->open($this->resolveFilePath($file)) !== true) {
+                $this->onError('invalid_scorm_archive_message');
+            }
+            $manifestResult = $this->findManifestInZip($zip);
+        } finally {
+            $this->closeManifestStream($manifestResult);
+            $zip->close();
+        }
+
+        if (!$manifestResult['found']) {
+            Log::error('ScormManager::validatePackage — imsmanifest.xml not found');
+            $this->onError('invalid_scorm_archive_message');
+        }
+
+        Log::info('ScormManager::validatePackage — manifest at: ' . $manifestResult['path']);
+    }
+
+    /**
+     * Parse and extract SCORM archive content.
+     *
+     * @param  string|UploadedFile  $file
+     */
+    private function generateScorm($file): array
+    {
+        $scormData = $this->parseScormArchive($file);
+
+        $this->scormDisk->unzipper($this->resolveFilePath($file), $this->uuid);
+
+        // If the manifest lived inside a subdirectory, prepend that prefix to
+        // all entry URLs so the browser can resolve assets correctly.
+        if (isset($scormData['manifestPath']) && str_contains($scormData['manifestPath'], '/')) {
+            $prefix = dirname($scormData['manifestPath']);
+            $original = $scormData['entryUrl'];
+            $scormData['entryUrl'] = $prefix . '/' . ltrim($scormData['entryUrl'], '/');
+            Log::info("ScormManager::generateScorm — entry URL adjusted: {$original} → {$scormData['entryUrl']}");
+        }
+
+        return [
+            'identifier' => $scormData['identifier'],
+            'uuid'       => $this->uuid,
+            'title'      => $scormData['title'],
+            'version'    => $scormData['version'],
+            'entryUrl'   => $scormData['entryUrl'],
+            'scos'       => $scormData['scos'],
+            'created_at' => $scormData['created_at'] ?? null,
+            'created_by' => $scormData['created_by'] ?? null,
+        ];
+    }
+
+    /**
+     * Read imsmanifest.xml from the zip and parse all relevant SCORM data.
+     *
+     * @param  string|UploadedFile  $file
+     */
+    private function parseScormArchive($file): array
+    {
+        $zip            = new ZipArchive();
+        $manifestResult = null;
+        $contents       = '';
+
+        try {
+            if ($zip->open($this->resolveFilePath($file)) !== true) {
+                $this->onError('cannot_load_imsmanifest_message');
+            }
+
+            $manifestResult = $this->findManifestInZip($zip);
+
+            if (!$manifestResult['found']) {
+                $this->onError('cannot_load_imsmanifest_message');
+            }
+
+            // Read the manifest stream in 8 KB chunks.
+            while (!feof($manifestResult['stream'])) {
+                $contents .= fread($manifestResult['stream'], 8192);
+            }
+        } finally {
+            $this->closeManifestStream($manifestResult);
+            $zip->close();
+        }
+
+        $dom = new DOMDocument();
+        $contents = $this->fixXmlEntities($contents);
+
+        if (!$dom->loadXML($contents)) {
+            $this->onError('cannot_load_imsmanifest_message');
+        }
+
+        return $this->extractManifestData($dom, $manifestResult['path']);
+    }
+
+    /**
+     * Pull all required fields from the parsed DOMDocument.
+     */
+    private function extractManifestData(DOMDocument $dom, string $manifestPath): array
+    {
+        $data       = [];
+        $manifest   = $dom->getElementsByTagName('manifest')->item(0);
+        $identifier = $manifest?->attributes->getNamedItem('identifier');
+
+        if ($identifier === null) {
+            $this->onError('invalid_scorm_manifest_identifier');
+        }
+
+        $data['identifier'] = $identifier->nodeValue;
+
+        $titles = $dom->getElementsByTagName('title');
+        $data['title'] = $titles->length > 0
+            ? Str::of($titles->item(0)->textContent)->trim('/n')->trim()->toString()
+            : '';
+
+        $schemaVersion = $dom->getElementsByTagName('schemaversion');
+
+        if ($schemaVersion->length === 0) {
+            $this->onError('invalid_scorm_version_message');
+        }
+
+        $data['version'] = match ($schemaVersion->item(0)->textContent) {
+            '1.2'             => Scorm::SCORM_12,
+            'CAM 1.3',
+            '2004 3rd Edition',
+            '2004 4th Edition' => Scorm::SCORM_2004,
+            default           => $this->onError('invalid_scorm_version_message'),
+        };
+
+        $scos = $this->scormLib->parseOrganizationsNode($dom);
+
+        if (empty($scos)) {
+            Log::error('ScormManager::extractManifestData — no SCOs found');
+            $this->onError('no_sco_in_scorm_archive_message');
+        }
+
+        $data['entryUrl']     = $scos[0]->entryUrl ?? $scos[0]->scoChildren[0]->entryUrl;
+        $data['scos']         = $scos;
+        $data['manifestPath'] = $manifestPath;
+        $data['created_at']   = $this->extractCreationDate($dom);
+        $data['created_by']   = $this->extractCreator($dom);
+
+        Log::info('ScormManager::extractManifestData — ' . count($scos) . ' SCO(s), entryUrl: ' . $data['entryUrl']);
+
+        return $data;
+    }
+
+    // =========================================================================
+    // Private — tracking data application
+    // =========================================================================
+
+    private function applyScorm12Data(ScoTracking $tracking, array $data): void
+    {
+        $tracking->setDetails($data);
+
+        if (!empty($data['cmi.suspend_data'])) {
+            $tracking->setSuspendData($data['cmi.suspend_data']);
+        }
+
+        $scoreRaw    = isset($data['cmi.core.score.raw'])  ? (int) $data['cmi.core.score.raw']  : null;
+        $scoreMin    = isset($data['cmi.core.score.min'])  ? (int) $data['cmi.core.score.min']  : null;
+        $scoreMax    = isset($data['cmi.core.score.max'])  ? (int) $data['cmi.core.score.max']  : null;
+        $lessonStatus  = $data['cmi.core.lesson_status']  ?? 'unknown';
+        $sessionTime   = $data['cmi.core.session_time']   ?? null;
+        $entry         = $data['cmi.core.entry']          ?? null;
+        $exit          = $data['cmi.core.exit']           ?? null;
+        $lessonLocation = $data['cmi.core.lesson_location'] ?? null;
+        $totalTime     = $data['cmi.core.total_time']     ?? 0;
+
+        $tracking->setEntry($entry);
+        $tracking->setExitMode($exit);
+        $tracking->setLessonLocation($lessonLocation);
+        $tracking->setSessionTime($this->convertTimeInHundredth($sessionTime));
+        $tracking->setTotalTime($this->convertTimeInHundredth($totalTime), Scorm::SCORM_12);
+        $tracking->setLessonStatus($lessonStatus);
+
+        // Keep best score
+        $bestScore = $tracking->getScoreRaw();
+        if (empty($bestScore) || (!is_null($scoreRaw) && $scoreRaw > (int) $bestScore)) {
+            $tracking->setScoreRaw($scoreRaw);
+            $tracking->setScoreMin($scoreMin);
+            $tracking->setScoreMax($scoreMax);
+        }
+
+        $progression = !empty($scoreRaw) ? (float) $scoreRaw : 0.0;
+        if ($progression === 0.0 && in_array($lessonStatus, ['completed', 'passed'], true)) {
+            $progression = 100.0;
+        }
+        if ($progression > $tracking->getProgression()) {
+            $tracking->setProgression($progression);
+        }
+    }
+
+    private function applyScorm2004Data(ScoTracking $tracking, array $data): void
+    {
+        $tracking->setDetails($data);
+
+        if (!empty($data['cmi.suspend_data'])) {
+            $tracking->setSuspendData($data['cmi.suspend_data']);
+        }
+
+        $completionStatus = $data['cmi.completion_status'] ?? 'unknown';
+        $successStatus    = $data['cmi.success_status']    ?? 'unknown';
+        $scoreRaw         = isset($data['cmi.score.raw'])    ? (int)   $data['cmi.score.raw']    : null;
+        $scoreMin         = isset($data['cmi.score.min'])    ? (int)   $data['cmi.score.min']    : null;
+        $scoreMax         = isset($data['cmi.score.max'])    ? (int)   $data['cmi.score.max']    : null;
+        $scoreScaled      = isset($data['cmi.score.scaled']) ? (float) $data['cmi.score.scaled'] : null;
+        $progression      = isset($data['cmi.progress_measure']) ? (float) $data['cmi.progress_measure'] : 0.0;
+
+        // Compute cumulative total time
+        $sessionTimeStr = isset($data['cmi.session_time'])
+            ? $this->formatSessionTime($data['cmi.session_time'])
+            : 'PT0S';
+
+        try {
+            $totalTime   = new DateInterval($tracking->getTotalTimeString() ?: 'PT0S');
+            $sessionTime = new DateInterval($sessionTimeStr);
+        } catch (Exception) {
+            $totalTime   = new DateInterval('PT0S');
+            $sessionTime = new DateInterval('PT0S');
+        }
+
+        $base = new DateTime('@0');
+        $base->add($totalTime)->add($sessionTime);
+        $totalTimeInterval = $this->retrieveIntervalFromSeconds($base->getTimestamp());
+
+        $data['cmi.total_time'] = $totalTimeInterval;
+        $tracking->setTotalTimeString($totalTimeInterval);
+
+        // Keep best score
+        $bestScore = $tracking->getScoreRaw();
+        if (empty($bestScore) || (!is_null($scoreRaw) && $scoreRaw > (int) $bestScore)) {
+            $tracking->setScoreRaw($scoreRaw);
+            $tracking->setScoreMin($scoreMin);
+            $tracking->setScoreMax($scoreMax);
+            $tracking->setScoreScaled($scoreScaled);
+        }
+
+        // Merge completion + success into a single lesson status
+        $lessonStatus = in_array($successStatus, ['passed', 'failed'], true)
+            ? $successStatus
+            : $completionStatus;
+
+        $tracking->setLessonStatus($lessonStatus);
+
+        $currentPriority  = self::STATUS_PRIORITY[$completionStatus]            ?? 0;
+        $existingPriority = self::STATUS_PRIORITY[$tracking->getCompletionStatus()] ?? 0;
+
+        if (empty($tracking->getCompletionStatus()) || $currentPriority > $existingPriority) {
+            $tracking->setCompletionStatus($completionStatus);
+        }
+
+        if ($progression === 0.0 && in_array($lessonStatus, ['completed', 'passed'], true)) {
+            $progression = 100.0;
+        }
+        if ($progression > $tracking->getProgression()) {
+            $tracking->setProgression($progression);
+        }
+    }
+
+    // =========================================================================
+    // Private — ZIP helpers
+    // =========================================================================
+
+    /**
+     * Find imsmanifest.xml inside a ZipArchive, checking the root first,
+     * then subdirectories.
+     *
+     * @return array{found: bool, path: string, stream: resource|null}
+     */
+    private function findManifestInZip(ZipArchive $zip): array
+    {
+        // Root check
+        $stream = $zip->getStream('imsmanifest.xml');
+        if ($stream !== false) {
+            Log::info('ScormManager::findManifestInZip — found at root');
+            return ['found' => true, 'path' => 'imsmanifest.xml', 'stream' => $stream];
+        }
+
+        // Subdirectory search
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $name = $zip->getNameIndex($i);
+            if (strtolower(basename($name)) === 'imsmanifest.xml') {
+                $stream = $zip->getStream($name);
+                if ($stream !== false) {
+                    Log::info('ScormManager::findManifestInZip — found at: ' . $name);
+                    return ['found' => true, 'path' => $name, 'stream' => $stream];
+                }
+            }
+        }
+
+        return ['found' => false, 'path' => '', 'stream' => null];
+    }
+
+    /** Close the manifest stream if it is still open. */
+    private function closeManifestStream(?array $manifestResult): void
+    {
+        if (
+            $manifestResult !== null
+            && isset($manifestResult['stream'])
+            && is_resource($manifestResult['stream'])
+        ) {
+            fclose($manifestResult['stream']);
+        }
+    }
+
+    // =========================================================================
+    // Private — manifest metadata extraction
+    // =========================================================================
+
+    /**
+     * Extract creation date from SCORM manifest LOM metadata.
+     * Returns an ISO-8601 string or null.
+     */
+    private function extractCreationDate(DOMDocument $dom): ?string
+    {
+        try {
+            $xpath = $this->buildXPath($dom);
+
+            foreach (
+                [
+                    '//lom:dateTime[ancestor::lom:contribute[lom:role/lom:value[text()="creator" or text()="author"]]]',
+                    '//lom:dateTime[ancestor::lom:contribute]',
+                    '//lom:dateTime',
+                ] as $query
+            ) {
+                $nodes = $this->safeXPathQuery($xpath, $query);
+                if ($nodes && $nodes->length > 0) {
+                    return $this->formatDate($nodes->item(0)->textContent);
+                }
+            }
+        } catch (Exception $e) {
+            Log::warning('ScormManager::extractCreationDate — ' . $e->getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the creator/author from SCORM manifest LOM metadata.
+     */
+    private function extractCreator(DOMDocument $dom): ?string
+    {
+        try {
+            $xpath = $this->buildXPath($dom);
+
+            foreach (
+                [
+                    '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="creator"]]]',
+                    '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="author"]]]',
+                    '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="publisher"]]]',
+                    '//lom:entity[ancestor::lom:contribute]',
+                    '//lom:entity',
+                ] as $query
+            ) {
+                $nodes = $this->safeXPathQuery($xpath, $query);
+                if ($nodes && $nodes->length > 0) {
+                    return trim($nodes->item(0)->textContent);
+                }
+            }
+        } catch (Exception $e) {
+            Log::warning('ScormManager::extractCreator — ' . $e->getMessage());
+        }
+
+        return null;
+    }
+
+    private function buildXPath(DOMDocument $dom): DOMXPath
+    {
+        $xpath = new DOMXPath($dom);
+        $xpath->registerNamespace('lom',    'http://ltsc.ieee.org/xsd/LOM');
+        $xpath->registerNamespace('adlcp',  'http://www.adlnet.org/xsd/adlcp_v1p3');
+        $xpath->registerNamespace('adlseq', 'http://www.adlnet.org/xsd/adlseq_v1p3');
+        $xpath->registerNamespace('adlnav', 'http://www.adlnet.org/xsd/adlnav_v1p3');
+        return $xpath;
+    }
+
+    private function safeXPathQuery(DOMXPath $xpath, string $query): \DOMNodeList|false
+    {
+        try {
+            return $xpath->query($query);
+        } catch (Exception $e) {
+            Log::warning('ScormManager::safeXPathQuery — "' . $query . '": ' . $e->getMessage());
             return false;
         }
     }
 
-    public function updateScoTracking($scoUuid, $userId, $data)
+    private function formatDate(string $dateString): ?string
     {
-        $tracking = $this->createScoTracking($scoUuid, $userId);
-        $tracking->setLatestDate(Carbon::now());
-        $sco    =   $tracking->getSco();
-        $scorm  =   ScormModel::where('id', $sco['scorm_id'])->firstOrFail();
-
-        $statusPriority = [
-            'unknown' => 0,
-            'not attempted' => 1,
-            'browsed' => 2,
-            'incomplete' => 3,
-            'completed' => 4,
-            'failed' => 5,
-            'passed' => 6,
-        ];
-
-        switch ($scorm->version) {
-            case Scorm::SCORM_12:
-                if (isset($data['cmi.suspend_data']) && !empty($data['cmi.suspend_data'])) {
-                    $tracking->setSuspendData($data['cmi.suspend_data']);
-                }
-
-                $scoreRaw = isset($data['cmi.core.score.raw']) ? intval($data['cmi.core.score.raw']) : null;
-                $scoreMin = isset($data['cmi.core.score.min']) ? intval($data['cmi.core.score.min']) : null;
-                $scoreMax = isset($data['cmi.core.score.max']) ? intval($data['cmi.core.score.max']) : null;
-                $lessonStatus = isset($data['cmi.core.lesson_status']) ? $data['cmi.core.lesson_status'] : 'unknown';
-                $sessionTime = isset($data['cmi.core.session_time']) ? $data['cmi.core.session_time'] : null;
-                $sessionTimeInHundredth = $this->convertTimeInHundredth($sessionTime);
-                $progression = !empty($scoreRaw) ? floatval($scoreRaw) : 0;
-                $entry  =   isset($data['cmi.core.entry']) ? $data['cmi.core.entry'] : null;
-                $exit  =   isset($data['cmi.core.exit']) ? $data['cmi.core.exit'] : null;
-                $lessonLocation =   isset($data['cmi.core.lesson_location']) ? $data['cmi.core.lesson_location'] : null;
-                $totalTime  =   isset($data['cmi.core.total_time']) ? $data['cmi.core.total_time'] : 0;
-
-                $tracking->setDetails($data);
-                $tracking->setEntry($entry);
-                $tracking->setExitMode($exit);
-                $tracking->setLessonLocation($lessonLocation);
-                $tracking->setSessionTime($sessionTimeInHundredth);
-
-                // Compute total time
-                $totalTimeInHundredth = $this->convertTimeInHundredth($totalTime);
-                $tracking->setTotalTime($totalTimeInHundredth, Scorm::SCORM_12);
-
-                $bestScore = $tracking->getScoreRaw();
-
-                // Update best score if the current score is better than the previous best score
-
-                if (empty($bestScore) || (!is_null($scoreRaw) && (int)$scoreRaw > (int)$bestScore)) {
-                    $tracking->setScoreRaw($scoreRaw);
-                    $tracking->setScoreMin($scoreMin);
-                    $tracking->setScoreMax($scoreMax);
-                }
-
-                $tracking->setLessonStatus($lessonStatus);
-                $bestStatus = $lessonStatus;
-
-                if (empty($progression) && ('completed' === $bestStatus || 'passed' === $bestStatus)) {
-                    $progression = 100;
-                }
-
-                if ($progression > $tracking->getProgression()) {
-                    $tracking->setProgression($progression);
-                }
-
-                break;
-
-            case Scorm::SCORM_2004:
-                $tracking->setDetails($data);
-
-                if (isset($data['cmi.suspend_data']) && !empty($data['cmi.suspend_data'])) {
-                    $tracking->setSuspendData($data['cmi.suspend_data']);
-                }
-
-                $dataSessionTime = isset($data['cmi.session_time']) ?
-                    $this->formatSessionTime($data['cmi.session_time']) :
-                    'PT0S';
-                $completionStatus = isset($data['cmi.completion_status']) ? $data['cmi.completion_status'] : 'unknown';
-                $successStatus = isset($data['cmi.success_status']) ? $data['cmi.success_status'] : 'unknown';
-                $scoreRaw = isset($data['cmi.score.raw']) ? intval($data['cmi.score.raw']) : null;
-                $scoreMin = isset($data['cmi.score.min']) ? intval($data['cmi.score.min']) : null;
-                $scoreMax = isset($data['cmi.score.max']) ? intval($data['cmi.score.max']) : null;
-                $scoreScaled = isset($data['cmi.score.scaled']) ? floatval($data['cmi.score.scaled']) : null;
-                $progression = isset($data['cmi.progress_measure']) ? floatval($data['cmi.progress_measure']) : 0;
-                $bestScore = $tracking->getScoreRaw();
-
-                // Computes total time
-                $totalTime = new \DateInterval($tracking->getTotalTimeString());
-
-                try {
-                    $sessionTime = new \DateInterval($dataSessionTime);
-                } catch (\Exception $e) {
-                    $sessionTime = new \DateInterval('PT0S');
-                }
-                $computedTime = new \DateTime();
-                $computedTime->setTimestamp(0);
-                $computedTime->add($totalTime);
-                $computedTime->add($sessionTime);
-                $computedTimeInSecond = $computedTime->getTimestamp();
-                $totalTimeInterval = $this->retrieveIntervalFromSeconds($computedTimeInSecond);
-                $data['cmi.total_time'] = $totalTimeInterval;
-                $tracking->setTotalTimeString($totalTimeInterval);
-
-                // Update best score if the current score is better than the previous best score
-                if (empty($bestScore) || (!is_null($scoreRaw) && (int)$scoreRaw > (int)$bestScore)) {
-                    $tracking->setScoreRaw($scoreRaw);
-                    $tracking->setScoreMin($scoreMin);
-                    $tracking->setScoreMax($scoreMax);
-                    $tracking->setScoreScaled($scoreScaled);
-                }
-
-                // Update best success status and completion status
-                $lessonStatus = $completionStatus;
-                if (in_array($successStatus, ['passed', 'failed'])) {
-                    $lessonStatus = $successStatus;
-                }
-
-                $tracking->setLessonStatus($lessonStatus);
-                $bestStatus = $lessonStatus;
-
-                if (
-                    empty($tracking->getCompletionStatus())
-                    || ($completionStatus !== $tracking->getCompletionStatus() && $statusPriority[$completionStatus] > $statusPriority[$tracking->getCompletionStatus()])
-                ) {
-                    // This is no longer needed as completionStatus and successStatus are merged together
-                    // I keep it for now for possible retro compatibility
-                    $tracking->setCompletionStatus($completionStatus);
-                }
-
-                if (empty($progression) && ('completed' === $bestStatus || 'passed' === $bestStatus)) {
-                    $progression = 100;
-                }
-
-                if ($progression > $tracking->getProgression()) {
-                    $tracking->setProgression($progression);
-                }
-
-                break;
+        if (empty($dateString)) {
+            return null;
         }
-
-        $updateResult   =   ScormScoTrackingModel::where('user_id', $tracking->getUserId())
-            ->where('sco_id', $sco['id'])
-            ->firstOrFail();
-
-        $updateResult->progression  =   $tracking->getProgression();
-        $updateResult->score_raw    =   $tracking->getScoreRaw();
-        $updateResult->score_min    =   $tracking->getScoreMin();
-        $updateResult->score_max    =   $tracking->getScoreMax();
-        $updateResult->score_scaled    =   $tracking->getScoreScaled();
-        $updateResult->lesson_status    =   $tracking->getLessonStatus();
-        $updateResult->completion_status    =   $tracking->getCompletionStatus();
-        $updateResult->session_time    =   $tracking->getSessionTime();
-        $updateResult->total_time_int    =   $tracking->getTotalTimeInt();
-        $updateResult->total_time_string    =   $tracking->getTotalTimeString();
-        $updateResult->entry    =   $tracking->getEntry();
-        $updateResult->suspend_data    =   $tracking->getSuspendData();
-        $updateResult->exit_mode    =   $tracking->getExitMode();
-        $updateResult->credit    =   $tracking->getCredit();
-        $updateResult->lesson_location    =   $tracking->getLessonLocation();
-        $updateResult->lesson_mode    =   $tracking->getLessonMode();
-        $updateResult->is_locked    =   $tracking->getIsLocked();
-        $updateResult->details    =   $tracking->getDetails();
-        $updateResult->latest_date    =   $tracking->getLatestDate();
-
-        $updateResult->save();
-
-        return $updateResult;
-    }
-
-    public function resetUserData($scormId, $userId)
-    {
-        $scos   =   ScormScoModel::where('scorm_id', $scormId)->get();
-
-        foreach ($scos as $sco) {
-            $scoTracking    =   ScormScoTrackingModel::where('sco_id', $sco->id)->where('user_id', $userId)->delete();
+        try {
+            return (new DateTime($dateString))->format('c');
+        } catch (Exception) {
+            return trim($dateString);
         }
     }
 
-    private function convertTimeInHundredth($time)
+    // =========================================================================
+    // Private — XML / time utilities
+    // =========================================================================
+
+    /**
+     * Escape unescaped ampersands in XML while preserving CDATA sections.
+     */
+    private function fixXmlEntities(string $xml): string
     {
-        if ($time != null) {
-            $timeInArray = explode(':', $time);
-            $timeInArraySec = explode('.', $timeInArray[2]);
-            $timeInHundredth = 0;
+        $cdata = [];
 
-            if (isset($timeInArraySec[1])) {
-                if (1 === strlen($timeInArraySec[1])) {
-                    $timeInArraySec[1] .= '0';
-                }
-                $timeInHundredth = intval($timeInArraySec[1]);
-            }
-            $timeInHundredth += intval($timeInArraySec[0]) * 100;
-            $timeInHundredth += intval($timeInArray[1]) * 6000;
-            $timeInHundredth += intval($timeInArray[0]) * 360000;
+        $xml = preg_replace_callback(
+            '/<!\[CDATA\[(.*?)\]\]>/s',
+            function (array $m) use (&$cdata): string {
+                $key         = '__CDATA_' . count($cdata) . '__';
+                $cdata[$key] = $m[0];
+                return $key;
+            },
+            $xml
+        );
 
-            return $timeInHundredth;
-        } else {
+        // Escape bare & that are not already part of a valid entity reference.
+        $xml = preg_replace('/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);)/', '&amp;', $xml);
+
+        return str_replace(array_keys($cdata), $cdata, $xml);
+    }
+
+    /**
+     * Convert HH:MM:SS.ss time string into hundredths of a second.
+     */
+    private function convertTimeInHundredth(?string $time): int
+    {
+        if (empty($time)) {
             return 0;
         }
+
+        [$h, $m, $secFull] = explode(':', $time);
+        [$sec, $frac]      = array_pad(explode('.', $secFull), 2, '0');
+
+        // Normalise fraction to two digits
+        $frac = str_pad(substr($frac, 0, 2), 2, '0');
+
+        return (int) $frac
+            + (int) $sec   * 100
+            + (int) $m     * 6_000
+            + (int) $h     * 360_000;
+    }
+
+    /** Convert a total number of seconds into a P…DT…H…M…S DateInterval string. */
+    private function retrieveIntervalFromSeconds(int $seconds): string
+    {
+        if ($seconds === 0) {
+            return 'PT0S';
+        }
+
+        $d = intdiv($seconds, 86_400);
+        $seconds %= 86_400;
+        $h = intdiv($seconds,  3_600);
+        $seconds %=  3_600;
+        $m = intdiv($seconds,     60);
+        $s = $seconds % 60;
+
+        return "P{$d}DT{$h}H{$m}M{$s}S";
     }
 
     /**
-     * Converts a time in seconds to a DateInterval string.
-     *
-     * @param int $seconds
-     *
-     * @return string
+     * Validate and normalise a SCORM 2004 session-time ISO-8601 string.
      */
-    private function retrieveIntervalFromSeconds($seconds)
+    private function formatSessionTime(string $sessionTime): string
     {
-        $result = '';
-        $remainingTime = (int) $seconds;
-
-        if (empty($remainingTime)) {
-            $result .= 'PT0S';
-        } else {
-            $nbDays = (int) ($remainingTime / 86400);
-            $remainingTime %= 86400;
-            $nbHours = (int) ($remainingTime / 3600);
-            $remainingTime %= 3600;
-            $nbMinutes = (int) ($remainingTime / 60);
-            $nbSeconds = $remainingTime % 60;
-            $result .= 'P' . $nbDays . 'DT' . $nbHours . 'H' . $nbMinutes . 'M' . $nbSeconds . 'S';
+        if ($sessionTime === 'PT') {
+            return 'PT0S';
         }
 
-        return $result;
+        $general = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?([0-9]+S)?$/';
+        $decimal = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?[0-9]+\.[0-9]{1,2}S$/';
+
+        if (preg_match($general, $sessionTime)) {
+            return $sessionTime;
+        }
+
+        if (preg_match($decimal, $sessionTime)) {
+            return (string) preg_replace('/\.[0-9]+S$/', 'S', $sessionTime);
+        }
+
+        return 'PT0S';
     }
 
-    private function formatSessionTime($sessionTime)
+    // =========================================================================
+    // Private — misc helpers
+    // =========================================================================
+
+    /**
+     * Return the real filesystem path whether $file is an UploadedFile or a
+     * plain string path (the OS tmp path from ScormDisk::readScormArchive).
+     *
+     * @param  string|UploadedFile  $file
+     */
+    private function resolveFilePath($file): string
     {
-        $formattedValue = 'PT0S';
-        $generalPattern = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?([0-9]+S)?$/';
-        $decimalPattern = '/^P([0-9]+Y)?([0-9]+M)?([0-9]+D)?T([0-9]+H)?([0-9]+M)?[0-9]+\.[0-9]{1,2}S$/';
-
-        if ('PT' !== $sessionTime) {
-            if (preg_match($generalPattern, $sessionTime)) {
-                $formattedValue = $sessionTime;
-            } elseif (preg_match($decimalPattern, $sessionTime)) {
-                $formattedValue = preg_replace(['/\.[0-9]+S$/'], ['S'], $sessionTime);
-            }
-        }
-
-        return $formattedValue;
+        return $file instanceof UploadedFile ? $file->getRealPath() : $file;
     }
 
     /**
-     * Get file size in bytes
-     * 
-     * @param string|UploadedFile $file
-     * @return int
+     * Copy all persisted fields from a ScormScoTrackingModel back into the
+     * ScoTracking entity so callers always work with a fully hydrated object.
      */
-    private function getFileSize($file)
+    private function hydrateTrackingFromModel(ScoTracking $tracking, ScormScoTrackingModel $model): void
+    {
+        $tracking->setUuid($model->uuid);
+        $tracking->setProgression($model->progression);
+        $tracking->setScoreRaw($model->score_raw);
+        $tracking->setScoreMin($model->score_min);
+        $tracking->setScoreMax($model->score_max);
+        $tracking->setScoreScaled($model->score_scaled);
+        $tracking->setLessonStatus($model->lesson_status);
+        $tracking->setCompletionStatus($model->completion_status);
+        $tracking->setSessionTime($model->session_time);
+        $tracking->setTotalTimeInt($model->total_time_int);
+        $tracking->setTotalTimeString($model->total_time_string);
+        $tracking->setEntry($model->entry);
+        $tracking->setSuspendData($model->suspend_data);
+        $tracking->setCredit($model->credit);
+        $tracking->setExitMode($model->exit_mode);
+        $tracking->setLessonLocation($model->lesson_location);
+        $tracking->setLessonMode($model->lesson_mode);
+        $tracking->setIsLocked($model->is_locked);
+        $tracking->setDetails($model->details);
+        $tracking->setLatestDate(Carbon::parse($model->latest_date));
+    }
+
+    /**
+     * Get file size in bytes.
+     *
+     * @param  string|UploadedFile  $file
+     */
+    private function getFileSize($file): int
     {
         if ($file instanceof UploadedFile) {
             return $file->getSize();
         }
 
-        if (is_string($file) && file_exists($file)) {
-            return filesize($file);
-        }
-
-        return 0;
+        return is_string($file) && file_exists($file) ? (int) filesize($file) : 0;
     }
 
     /**
-     * Extract creation date from SCORM manifest metadata following SCORM standards
+     * Clean up any partially-written files and throw.
+     *
+     * @return never
      */
-    private function extractCreationDate(DOMDocument $dom)
-    {
-        try {
-            $xpath = new \DOMXPath($dom);
-
-            // Register common SCORM namespaces with error handling
-            $this->registerScormNamespaces($xpath);
-
-            // SCORM 2004: Look for lom:lom/lom:lifeCycle/lom:contribute/lom:date/lom:dateTime
-            // Priority 1: Creator/Author contribution date
-            $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime[ancestor::lom:contribute[lom:role/lom:value[text()="creator" or text()="author"]]]');
-            if ($dateNodes && $dateNodes->length > 0) {
-                return $this->formatDate($dateNodes->item(0)->textContent);
-            }
-
-            // Priority 2: Any contribution date
-            $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime[ancestor::lom:contribute]');
-            if ($dateNodes && $dateNodes->length > 0) {
-                return $this->formatDate($dateNodes->item(0)->textContent);
-            }
-
-            // Priority 3: Any dateTime in metadata
-            $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime');
-            if ($dateNodes && $dateNodes->length > 0) {
-                return $this->formatDate($dateNodes->item(0)->textContent);
-            }
-
-            // SCORM 1.2: Look for <schema> and <schemaversion> to get creation context
-            $schemaNodes = $this->safeXPathQuery($xpath, '//schema');
-            if ($schemaNodes && $schemaNodes->length > 0) {
-                $schema = $schemaNodes->item(0)->textContent;
-                if (strpos($schema, 'ADL SCORM') !== false) {
-                    // For SCORM 1.2, we might not have creation date in manifest
-                    // Return null as it's not standard in SCORM 1.2
-                    return null;
-                }
-            }
-        } catch (\Exception $e) {
-            \Log::warning('extractCreationDate: Error extracting creation date - ' . $e->getMessage());
-        }
-
-        return null;
-    }
-
-    /**
-     * Extract creator from SCORM manifest metadata following SCORM standards
-     */
-    private function extractCreator(DOMDocument $dom)
-    {
-        try {
-            $xpath = new \DOMXPath($dom);
-
-            // Register common SCORM namespaces with error handling
-            $this->registerScormNamespaces($xpath);
-
-            // SCORM 2004: Look for lom:lom/lom:lifeCycle/lom:contribute/lom:entity
-            // Priority 1: Creator role
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="creator"]]]');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // Priority 2: Author role
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="author"]]]');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // Priority 3: Publisher role
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="publisher"]]]');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // Priority 4: Any entity in contribute section
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute]');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // Priority 5: Any entity in metadata
-            $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity');
-            if ($entityNodes && $entityNodes->length > 0) {
-                return trim($entityNodes->item(0)->textContent);
-            }
-
-            // SCORM 1.2: Look for organization or other creator information
-            // SCORM 1.2 typically doesn't have detailed creator metadata
-            $orgNodes = $this->safeXPathQuery($xpath, '//organization');
-            if ($orgNodes && $orgNodes->length > 0) {
-                // For SCORM 1.2, we might not have creator info in manifest
-                return null;
-            }
-        } catch (\Exception $e) {
-            \Log::warning('extractCreator: Error extracting creator - ' . $e->getMessage());
-        }
-
-        return null;
-    }
-
-    /**
-     * Format date string to ISO 8601 format
-     */
-    private function formatDate($dateString)
-    {
-        if (empty($dateString)) {
-            return null;
-        }
-
-        // Try to parse the date and convert to ISO 8601
-        try {
-            $date = new \DateTime($dateString);
-            return $date->format('c'); // ISO 8601 format
-        } catch (\Exception $e) {
-            // If parsing fails, return the original string
-            return trim($dateString);
-        }
-    }
-
-    /**
-     * Register SCORM namespaces safely
-     */
-    private function registerScormNamespaces(\DOMXPath $xpath)
-    {
-        try {
-            $xpath->registerNamespace('lom', 'http://ltsc.ieee.org/xsd/LOM');
-            $xpath->registerNamespace('adlcp', 'http://www.adlnet.org/xsd/adlcp_v1p3');
-            $xpath->registerNamespace('adlseq', 'http://www.adlnet.org/xsd/adlseq_v1p3');
-            $xpath->registerNamespace('adlnav', 'http://www.adlnet.org/xsd/adlnav_v1p3');
-        } catch (\Exception $e) {
-            \Log::warning('registerScormNamespaces: Error registering namespaces - ' . $e->getMessage());
-        }
-    }
-
-    /**
-     * Execute XPath query safely with error handling
-     */
-    private function safeXPathQuery(\DOMXPath $xpath, $query)
-    {
-        try {
-            return $xpath->query($query);
-        } catch (\Exception $e) {
-            \Log::warning('safeXPathQuery: Error executing XPath query "' . $query . '" - ' . $e->getMessage());
-            return false;
-        }
-    }
-
-    /**
-     * Fix XML entities by escaping unescaped ampersands while preserving CDATA sections
-     * 
-     * @param string $xml
-     * @return string
-     */
-    private function fixXmlEntities($xml)
-    {
-        // Extract CDATA sections with placeholders
-        $cdataSections = [];
-        $xml = preg_replace_callback(
-            '/<!\[CDATA\[(.*?)\]\]>/s',
-            function ($matches) use (&$cdataSections) {
-                $placeholder = '__CDATA_' . count($cdataSections) . '__';
-                $cdataSections[$placeholder] = $matches[0];
-                return $placeholder;
-            },
-            $xml
-        );
-
-        // Escape ampersands not part of valid XML entities
-        // Valid: &name; &#123; &#xAB; &#XAB;
-        $xml = preg_replace('/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);)/', '&amp;', $xml);
-
-        // Restore CDATA sections
-        return str_replace(array_keys($cdataSections), $cdataSections, $xml);
-    }
-
-    /**
-     * Clean resources and throw exception.
-     */
-    private function onError($msg)
+    private function onError(string $msg): never
     {
         $this->scormDisk->deleteScorm($this->uuid);
         throw new InvalidScormArchiveException($msg);

--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -84,7 +84,7 @@ class ScormManager
     {
         // Look for imsmanifest.xml in root directory first
         $manifestStream = $zip->getStream('imsmanifest.xml');
-        
+
         if ($manifestStream) {
             \Log::info('Found imsmanifest.xml in root directory');
             return [
@@ -93,13 +93,13 @@ class ScormManager
                 'stream' => $manifestStream
             ];
         }
-        
+
         // Search for imsmanifest.xml in subdirectories
         \Log::info('imsmanifest.xml not found in root, searching subdirectories...');
-        
+
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $filename = $zip->getNameIndex($i);
-            
+
             // Check if this file is imsmanifest.xml (case insensitive)
             if (strtolower(basename($filename)) === 'imsmanifest.xml') {
                 $manifestStream = $zip->getStream($filename);
@@ -113,7 +113,7 @@ class ScormManager
                 }
             }
         }
-        
+
         return [
             'found' => false,
             'path' => '',
@@ -133,7 +133,7 @@ class ScormManager
 
         try {
             $openValue = $zip->open($file);
-            
+
             if ($openValue !== true) {
                 \Log::error('Zip open errorCode: ' . $openValue);
                 $this->onError('invalid_scorm_archive_message');
@@ -147,7 +147,7 @@ class ScormManager
             }
             $zip->close();
         }
-        
+
         if (!$manifestResult['found']) {
             \Log::error('imsmanifest.xml not found anywhere in the ZIP archive');
             $this->onError('invalid_scorm_archive_message');
@@ -211,14 +211,14 @@ class ScormManager
         $scorm->entry_url =   $scormData['entryUrl'];
         $scorm->identifier =   $scormData['identifier'];
         $scorm->origin_file =   $filename;
-        
+
         // Auto-detect and set metadata
         $scorm->metadata = [
             'package_size' => $this->getFileSize($file),
             'created_at' => $scormData['created_at'] ?? null,
             'created_by' => $scormData['created_by'] ?? null
         ];
-        
+
         $scorm->save();
 
         if (!empty($scormData['scos']) && is_array($scormData['scos'])) {
@@ -243,14 +243,14 @@ class ScormManager
     private function saveScormScosRecursively($scorm_id, $scoData, $sco_parent_id = null)
     {
         $sco = $this->saveScormScos($scorm_id, $scoData, $sco_parent_id);
-        
+
         // Recursively save children
         if ($scoData->scoChildren && is_array($scoData->scoChildren)) {
             foreach ($scoData->scoChildren as $scoChild) {
                 $this->saveScormScosRecursively($scorm_id, $scoChild, $sco->id);
             }
         }
-        
+
         return $sco;
     }
 
@@ -279,9 +279,9 @@ class ScormManager
         $sco->score_decimal  =   $scoData->scoreToPassDecimal;
         $sco->completion_threshold  =   $scoData->completionThreshold;
         $sco->prerequisites  =   $scoData->prerequisites;
-        
+
         $sco->save();
-        
+
         \Log::info("saveScormScos: Saved SCO - " . $sco->identifier);
         return $sco;
     }
@@ -298,14 +298,14 @@ class ScormManager
 
         try {
             $openValue = $zip->open($file);
-            
+
             if ($openValue !== true) {
                 \Log::error('Failed to open ZIP file in parseScormArchive. Error code: ' . $openValue);
                 $this->onError('cannot_load_imsmanifest_message');
             }
-            
+
             $manifestResult = $this->findManifestInZip($zip);
-            
+
             if (!$manifestResult['found']) {
                 $this->onError('cannot_load_imsmanifest_message');
             }
@@ -367,12 +367,12 @@ class ScormManager
 
         $data['entryUrl'] = $scos[0]->entryUrl ?? $scos[0]->scoChildren[0]->entryUrl;
         $data['scos'] = $scos;
-        
+
         \Log::info('parseScormArchive: Found ' . count($scos) . ' SCOs, entryUrl: ' . $data['entryUrl']);
-        
+
         // Include manifest path for later use in entry URL adjustment
         $data['manifestPath'] = $manifestResult['path'];
-        
+
         // Extract creation date and creator from manifest metadata
         $data['created_at'] = $this->extractCreationDate($dom);
         $data['created_by'] = $this->extractCreator($dom);
@@ -873,11 +873,11 @@ class ScormManager
         if ($file instanceof UploadedFile) {
             return $file->getSize();
         }
-        
+
         if (is_string($file) && file_exists($file)) {
             return filesize($file);
         }
-        
+
         return 0;
     }
 
@@ -888,29 +888,29 @@ class ScormManager
     {
         try {
             $xpath = new \DOMXPath($dom);
-            
+
             // Register common SCORM namespaces with error handling
             $this->registerScormNamespaces($xpath);
-            
+
             // SCORM 2004: Look for lom:lom/lom:lifeCycle/lom:contribute/lom:date/lom:dateTime
             // Priority 1: Creator/Author contribution date
             $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime[ancestor::lom:contribute[lom:role/lom:value[text()="creator" or text()="author"]]]');
             if ($dateNodes && $dateNodes->length > 0) {
                 return $this->formatDate($dateNodes->item(0)->textContent);
             }
-            
+
             // Priority 2: Any contribution date
             $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime[ancestor::lom:contribute]');
             if ($dateNodes && $dateNodes->length > 0) {
                 return $this->formatDate($dateNodes->item(0)->textContent);
             }
-            
+
             // Priority 3: Any dateTime in metadata
             $dateNodes = $this->safeXPathQuery($xpath, '//lom:dateTime');
             if ($dateNodes && $dateNodes->length > 0) {
                 return $this->formatDate($dateNodes->item(0)->textContent);
             }
-            
+
             // SCORM 1.2: Look for <schema> and <schemaversion> to get creation context
             $schemaNodes = $this->safeXPathQuery($xpath, '//schema');
             if ($schemaNodes && $schemaNodes->length > 0) {
@@ -921,11 +921,10 @@ class ScormManager
                     return null;
                 }
             }
-            
         } catch (\Exception $e) {
             \Log::warning('extractCreationDate: Error extracting creation date - ' . $e->getMessage());
         }
-        
+
         return null;
     }
 
@@ -936,41 +935,41 @@ class ScormManager
     {
         try {
             $xpath = new \DOMXPath($dom);
-            
+
             // Register common SCORM namespaces with error handling
             $this->registerScormNamespaces($xpath);
-            
+
             // SCORM 2004: Look for lom:lom/lom:lifeCycle/lom:contribute/lom:entity
             // Priority 1: Creator role
             $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="creator"]]]');
             if ($entityNodes && $entityNodes->length > 0) {
                 return trim($entityNodes->item(0)->textContent);
             }
-            
+
             // Priority 2: Author role
             $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="author"]]]');
             if ($entityNodes && $entityNodes->length > 0) {
                 return trim($entityNodes->item(0)->textContent);
             }
-            
+
             // Priority 3: Publisher role
             $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute[lom:role/lom:value[text()="publisher"]]]');
             if ($entityNodes && $entityNodes->length > 0) {
                 return trim($entityNodes->item(0)->textContent);
             }
-            
+
             // Priority 4: Any entity in contribute section
             $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity[ancestor::lom:contribute]');
             if ($entityNodes && $entityNodes->length > 0) {
                 return trim($entityNodes->item(0)->textContent);
             }
-            
+
             // Priority 5: Any entity in metadata
             $entityNodes = $this->safeXPathQuery($xpath, '//lom:entity');
             if ($entityNodes && $entityNodes->length > 0) {
                 return trim($entityNodes->item(0)->textContent);
             }
-            
+
             // SCORM 1.2: Look for organization or other creator information
             // SCORM 1.2 typically doesn't have detailed creator metadata
             $orgNodes = $this->safeXPathQuery($xpath, '//organization');
@@ -978,11 +977,10 @@ class ScormManager
                 // For SCORM 1.2, we might not have creator info in manifest
                 return null;
             }
-            
         } catch (\Exception $e) {
             \Log::warning('extractCreator: Error extracting creator - ' . $e->getMessage());
         }
-        
+
         return null;
     }
 
@@ -994,7 +992,7 @@ class ScormManager
         if (empty($dateString)) {
             return null;
         }
-        
+
         // Try to parse the date and convert to ISO 8601
         try {
             $date = new \DateTime($dateString);
@@ -1034,22 +1032,31 @@ class ScormManager
     }
 
     /**
-     * Fix XML entities by escaping unescaped ampersands
-     * This prevents "xmlParseEntityRef: no name in Entity" errors
+     * Fix XML entities by escaping unescaped ampersands while preserving CDATA sections
      * 
      * @param string $xml
      * @return string
      */
     private function fixXmlEntities($xml)
     {
-        // Replace unescaped ampersands that are not part of valid XML entities
-        // Valid XML entities are:
-        // - Named entities: &amp; &lt; &gt; &quot; &apos; etc.
-        // - Numeric entities: &#123; (decimal) or &#x7B; (hexadecimal)
-        // This regex matches & that are NOT followed by a valid entity pattern
-        $xml = preg_replace('/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#x[0-9a-fA-F]+);)/', '&amp;', $xml);
-        
-        return $xml;
+        // Extract CDATA sections with placeholders
+        $cdataSections = [];
+        $xml = preg_replace_callback(
+            '/<!\[CDATA\[(.*?)\]\]>/s',
+            function ($matches) use (&$cdataSections) {
+                $placeholder = '__CDATA_' . count($cdataSections) . '__';
+                $cdataSections[$placeholder] = $matches[0];
+                return $placeholder;
+            },
+            $xml
+        );
+
+        // Escape ampersands not part of valid XML entities
+        // Valid: &name; &#123; &#xAB; &#XAB;
+        $xml = preg_replace('/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);)/', '&amp;', $xml);
+
+        // Restore CDATA sections
+        return str_replace(array_keys($cdataSections), $cdataSections, $xml);
     }
 
     /**

--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -323,6 +323,9 @@ class ScormManager
 
         $dom = new DOMDocument();
 
+        // Fix XML entity errors by escaping unescaped ampersands
+        $contents = $this->fixXmlEntities($contents);
+
         if (!$dom->loadXML($contents)) {
             $this->onError('cannot_load_imsmanifest_message');
         }
@@ -1028,6 +1031,25 @@ class ScormManager
             \Log::warning('safeXPathQuery: Error executing XPath query "' . $query . '" - ' . $e->getMessage());
             return false;
         }
+    }
+
+    /**
+     * Fix XML entities by escaping unescaped ampersands
+     * This prevents "xmlParseEntityRef: no name in Entity" errors
+     * 
+     * @param string $xml
+     * @return string
+     */
+    private function fixXmlEntities($xml)
+    {
+        // Replace unescaped ampersands that are not part of valid XML entities
+        // Valid XML entities are:
+        // - Named entities: &amp; &lt; &gt; &quot; &apos; etc.
+        // - Numeric entities: &#123; (decimal) or &#x7B; (hexadecimal)
+        // This regex matches & that are NOT followed by a valid entity pattern
+        $xml = preg_replace('/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#x[0-9a-fA-F]+);)/', '&amp;', $xml);
+        
+        return $xml;
     }
 
     /**

--- a/src/Manager/ScormManager.php
+++ b/src/Manager/ScormManager.php
@@ -8,7 +8,6 @@ use DateTime;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Peopleaps\Scorm\Contract\UnzipperInterface;
 use Peopleaps\Scorm\Entity\Scorm;
@@ -23,14 +22,9 @@ class ScormManager
 {
     private readonly ScormDisk $scormDisk;
 
-    public function __construct(?UnzipperInterface $unzipper = null)
+    public function __construct(UnzipperInterface $unzipper)
     {
-        $this->scormDisk = new ScormDisk(
-            $unzipper ?? new LocalUnzipper(
-                Storage::disk(config('scorm.archive')),
-                Storage::disk(config('scorm.disk')),
-            )
-        );
+        $this->scormDisk = new ScormDisk($unzipper);
     }
 
     // -------------------------------------------------------------------------

--- a/src/Model/ScormModel.php
+++ b/src/Model/ScormModel.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $title
  * @property string $version
  * @property string $entryUrl
+ * @property array|null $metadata
  */
 class ScormModel extends Model
 {
@@ -32,8 +33,18 @@ class ScormModel extends Model
         'uuid',
         'identifier',
         'entry_url',
+        'metadata',
         'created_at',
         'updated_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'metadata' => 'array',
     ];
 
     /**
@@ -52,5 +63,84 @@ class ScormModel extends Model
     public function scos()
     {
         return $this->hasMany(ScormScoModel::class, 'scorm_id', 'id');
+    }
+
+    /**
+     * Get a specific metadata value
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function getMetadata($key, $default = null)
+    {
+        $metadata = $this->metadata ?? [];
+        return $metadata[$key] ?? $default;
+    }
+
+    /**
+     * Set a specific metadata value
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
+    public function setMetadata($key, $value)
+    {
+        $metadata = $this->metadata ?? [];
+        $metadata[$key] = $value;
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * Get package creation date from manifest
+     *
+     * @return string|null
+     */
+    public function getPackageCreationDate()
+    {
+        return $this->getMetadata('created_at');
+    }
+
+    /**
+     * Get package size
+     *
+     * @return int|null
+     */
+    public function getPackageSize()
+    {
+        return $this->getMetadata('package_size');
+    }
+
+    /**
+     * Get package creator from manifest
+     *
+     * @return string|null
+     */
+    public function getPackageCreator()
+    {
+        return $this->getMetadata('created_by');
+    }
+
+    /**
+     * Get all metadata as array
+     *
+     * @return array
+     */
+    public function getAllMetadata()
+    {
+        return $this->metadata ?? [];
+    }
+
+    /**
+     * Check if metadata has a specific key
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function hasMetadata($key)
+    {
+        $metadata = $this->metadata ?? [];
+        return array_key_exists($key, $metadata);
     }
 }

--- a/src/Model/ScormScoModel.php
+++ b/src/Model/ScormScoModel.php
@@ -8,6 +8,26 @@ use Illuminate\Database\Eloquent\Model;
 
 class ScormScoModel extends Model
 {
+    /** @var array<int, string> */
+    protected $fillable = [
+        'scorm_id',
+        'uuid',
+        'sco_parent_id',
+        'entry_url',
+        'identifier',
+        'title',
+        'visible',
+        'sco_parameters',
+        'launch_data',
+        'max_time_allowed',
+        'time_limit_action',
+        'block',
+        'score_int',
+        'score_decimal',
+        'completion_threshold',
+        'prerequisites',
+    ];
+
     public function getTable()
     {
         return config('scorm.table_names.scorm_sco_table', parent::getTable());

--- a/src/ScormServiceProvider.php
+++ b/src/ScormServiceProvider.php
@@ -39,6 +39,10 @@ class ScormServiceProvider extends ServiceProvider
         ], 'migrations');
 
         $this->publishes([
+            __DIR__ . '/../database/migrations/add_metadata_to_scorm_table.php.stub' => $this->getMigrationFileName('add_metadata_to_scorm_table.php'),
+        ], 'migrations');
+
+        $this->publishes([
             __DIR__ . '/../resources/lang/en-US/scorm.php' => resource_path('lang/en-US/scorm.php'),
         ]);
     }
@@ -54,12 +58,12 @@ class ScormServiceProvider extends ServiceProvider
 
         $filesystem = $this->app->make(Filesystem::class);
 
+        // Extract the base name without extension for glob pattern
+        $baseName = pathinfo($migrationFileName, PATHINFO_FILENAME);
+
         return Collection::make($this->app->databasePath() . DIRECTORY_SEPARATOR . 'migrations' . DIRECTORY_SEPARATOR)
-            ->flatMap(function ($path) use ($filesystem) {
-                return $filesystem->glob($path . '*_create_scorm_tables.php');
-            })->push($this->app->databasePath() . "/migrations/{$timestamp}_create_scorm_tables.php")
-            ->flatMap(function ($path) use ($filesystem, $migrationFileName) {
-                return $filesystem->glob($path . '*_' . $migrationFileName);
+            ->flatMap(function ($path) use ($filesystem, $baseName) {
+                return $filesystem->glob($path . '*_' . $baseName . '.php');
             })
             ->push($this->app->databasePath() . "/migrations/{$timestamp}_{$migrationFileName}")
             ->first();

--- a/src/ScormServiceProvider.php
+++ b/src/ScormServiceProvider.php
@@ -7,15 +7,37 @@ namespace Peopleaps\Scorm;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
+use Peopleaps\Scorm\Contract\UnzipperInterface;
 use Peopleaps\Scorm\Manager\ScormManager;
 
 class ScormServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->bind('scorm-manager', function ($app) {
-            return new ScormManager();
+
+        // Default unzipper — applications can rebind UnzipperInterface before
+        // resolving ScormManager to swap in a different implementation (e.g. LambdaUnzipper).
+        $this->app->bind(UnzipperInterface::class, function () {
+            $archive = config('scorm.archive');
+            $scorm   = config('scorm.disk');
+
+            if (empty($archive) || empty($scorm)) {
+                throw new \InvalidArgumentException('scorm.archive and scorm.disk must both be configured.');
+            }
+
+            return new LocalUnzipper(
+                Storage::disk($archive),
+                Storage::disk($scorm),
+            );
         });
+
+        // ScormManager is the only public entry point — it wires ScormDisk internally.
+        $this->app->bind(ScormManager::class, function ($app) {
+            return new ScormManager($app->make(UnzipperInterface::class));
+        });
+
+        // Preserve the string alias for backwards compatibility.
+        $this->app->alias(ScormManager::class, 'scorm-manager');
     }
 
     public function boot()


### PR DESCRIPTION
Introduce UnzipperInterface to define a contract for SCORM zip extraction. Implement LocalUnzipper to handle extraction from the archive disk to the SCORM disk using PHP's ZipArchive. Update ScormServiceProvider to bind the UnzipperInterface and ensure backward compatibility with ScormManager. 
Enhance ScormDisk to utilize the new unzipper for content extraction, improving modularity and flexibility in SCORM package handling.

- Enhance the README.md by introducing a section on choosing an unzipper strategy for SCORM package extraction, 
- providing examples for Laravel container binding and manual instantiation, Ex. LambdaUnzipper service to separate process away from production server.
- Refactor the ScormManager constructor to require an UnzipperInterface implementation, 
- improving dependency management and flexibility in handling different unzipper strategies.